### PR TITLE
Add types, strategy, validation skeleton

### DIFF
--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -292,6 +292,667 @@
     ]
    },
    {
+    "path": "/api/v1/namespaces/{namespaces}/daemoncontrollers",
+    "description": "API at /api/v1 version v1",
+    "operations": [
+     {
+      "type": "v1.DaemonControllerList",
+      "method": "GET",
+      "summary": "list or watch objects of kind DaemonController",
+      "nickname": "listDaemonController",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "labelSelector",
+        "description": "a selector to restrict the list of returned objects by their labels; defaults to everything",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "fieldSelector",
+        "description": "a selector to restrict the list of returned objects by their fields; defaults to everything",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "watch",
+        "description": "watch for changes to the described resources and return them as a stream of add, update, and remove notifications; specify resourceVersion",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "resourceVersion",
+        "description": "when specified with a watch call, shows changes that occur after that particular version of a resource; defaults to changes from the beginning of history",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespaces",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.DaemonControllerList"
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "v1.DaemonController",
+      "method": "POST",
+      "summary": "create a DaemonController",
+      "nickname": "createDaemonController",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1.DaemonController",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespaces",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.DaemonController"
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1/watch/namespaces/{namespaces}/daemoncontrollers",
+    "description": "API at /api/v1 version v1",
+    "operations": [
+     {
+      "type": "json.WatchEvent",
+      "method": "GET",
+      "summary": "watch individual changes to a list of DaemonController",
+      "nickname": "watchDaemonControllerList",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "labelSelector",
+        "description": "a selector to restrict the list of returned objects by their labels; defaults to everything",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "fieldSelector",
+        "description": "a selector to restrict the list of returned objects by their fields; defaults to everything",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "watch",
+        "description": "watch for changes to the described resources and return them as a stream of add, update, and remove notifications; specify resourceVersion",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "resourceVersion",
+        "description": "when specified with a watch call, shows changes that occur after that particular version of a resource; defaults to changes from the beginning of history",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespaces",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "json.WatchEvent"
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1/namespaces/{namespaces}/daemoncontrollers/{name}",
+    "description": "API at /api/v1 version v1",
+    "operations": [
+     {
+      "type": "v1.DaemonController",
+      "method": "GET",
+      "summary": "read the specified DaemonController",
+      "nickname": "readDaemonController",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespaces",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the DaemonController",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.DaemonController"
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "v1.DaemonController",
+      "method": "PUT",
+      "summary": "replace the specified DaemonController",
+      "nickname": "replaceDaemonController",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1.DaemonController",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespaces",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the DaemonController",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.DaemonController"
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "v1.DaemonController",
+      "method": "PATCH",
+      "summary": "partially update the specified DaemonController",
+      "nickname": "patchDaemonController",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespaces",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the DaemonController",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "string"
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "application/json-patch+json",
+       "application/merge-patch+json",
+       "application/strategic-merge-patch+json"
+      ]
+     },
+     {
+      "type": "v1.Status",
+      "method": "DELETE",
+      "summary": "delete a DaemonController",
+      "nickname": "deleteDaemonController",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1.DeleteOptions",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespaces",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the DaemonController",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.Status"
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1/watch/namespaces/{namespaces}/daemoncontrollers/{name}",
+    "description": "API at /api/v1 version v1",
+    "operations": [
+     {
+      "type": "json.WatchEvent",
+      "method": "GET",
+      "summary": "watch changes to an object of kind DaemonController",
+      "nickname": "watchDaemonController",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "labelSelector",
+        "description": "a selector to restrict the list of returned objects by their labels; defaults to everything",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "fieldSelector",
+        "description": "a selector to restrict the list of returned objects by their fields; defaults to everything",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "watch",
+        "description": "watch for changes to the described resources and return them as a stream of add, update, and remove notifications; specify resourceVersion",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "resourceVersion",
+        "description": "when specified with a watch call, shows changes that occur after that particular version of a resource; defaults to changes from the beginning of history",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespaces",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the DaemonController",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "json.WatchEvent"
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1/daemoncontrollers",
+    "description": "API at /api/v1 version v1",
+    "operations": [
+     {
+      "type": "v1.DaemonControllerList",
+      "method": "GET",
+      "summary": "list or watch objects of kind DaemonController",
+      "nickname": "listDaemonController",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "labelSelector",
+        "description": "a selector to restrict the list of returned objects by their labels; defaults to everything",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "fieldSelector",
+        "description": "a selector to restrict the list of returned objects by their fields; defaults to everything",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "watch",
+        "description": "watch for changes to the described resources and return them as a stream of add, update, and remove notifications; specify resourceVersion",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "resourceVersion",
+        "description": "when specified with a watch call, shows changes that occur after that particular version of a resource; defaults to changes from the beginning of history",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.DaemonControllerList"
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "v1.DaemonController",
+      "method": "POST",
+      "summary": "create a DaemonController",
+      "nickname": "createDaemonController",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1.DaemonController",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.DaemonController"
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1/watch/daemoncontrollers",
+    "description": "API at /api/v1 version v1",
+    "operations": [
+     {
+      "type": "json.WatchEvent",
+      "method": "GET",
+      "summary": "watch individual changes to a list of DaemonController",
+      "nickname": "watchDaemonControllerList",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "labelSelector",
+        "description": "a selector to restrict the list of returned objects by their labels; defaults to everything",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "fieldSelector",
+        "description": "a selector to restrict the list of returned objects by their fields; defaults to everything",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "watch",
+        "description": "watch for changes to the described resources and return them as a stream of add, update, and remove notifications; specify resourceVersion",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "resourceVersion",
+        "description": "when specified with a watch call, shows changes that occur after that particular version of a resource; defaults to changes from the beginning of history",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "json.WatchEvent"
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
     "path": "/api/v1/namespaces/{namespaces}/endpoints",
     "description": "API at /api/v1 version v1",
     "operations": [
@@ -10907,8 +11568,8 @@
      }
     }
    },
-   "v1.EndpointsList": {
-    "id": "v1.EndpointsList",
+   "v1.DaemonControllerList": {
+    "id": "v1.DaemonControllerList",
     "required": [
      "items"
     ],
@@ -10922,23 +11583,18 @@
       "description": "version of the schema the object should have"
      },
      "metadata": {
-      "$ref": "v1.ListMeta",
-      "description": "standard list metadata; see http://docs.k8s.io/api-conventions.md#metadata"
+      "$ref": "v1.ListMeta"
      },
      "items": {
       "type": "array",
       "items": {
-       "$ref": "v1.Endpoints"
-      },
-      "description": "list of endpoints"
+       "$ref": "v1.DaemonController"
+      }
      }
     }
    },
-   "v1.Endpoints": {
-    "id": "v1.Endpoints",
-    "required": [
-     "subsets"
-    ],
+   "v1.DaemonController": {
+    "id": "v1.DaemonController",
     "properties": {
      "kind": {
       "type": "string",
@@ -10949,71 +11605,780 @@
       "description": "version of the schema the object should have"
      },
      "metadata": {
+      "$ref": "v1.ObjectMeta"
+     },
+     "spec": {
+      "$ref": "v1.DaemonControllerSpec"
+     },
+     "status": {
+      "$ref": "v1.DaemonControllerStatus"
+     }
+    }
+   },
+   "v1.DaemonControllerSpec": {
+    "id": "v1.DaemonControllerSpec",
+    "properties": {
+     "template": {
+      "$ref": "v1.PodTemplateSpec"
+     }
+    }
+   },
+   "v1.PodTemplateSpec": {
+    "id": "v1.PodTemplateSpec",
+    "properties": {
+     "metadata": {
       "$ref": "v1.ObjectMeta",
       "description": "standard object metadata; see http://docs.k8s.io/api-conventions.md#metadata"
      },
-     "subsets": {
-      "type": "array",
-      "items": {
-       "$ref": "v1.EndpointSubset"
-      },
-      "description": "sets of addresses and ports that comprise a service"
+     "spec": {
+      "$ref": "v1.PodSpec",
+      "description": "specification of the desired behavior of the pod; http://docs.k8s.io/api-conventions.md#spec-and-status"
      }
     }
    },
-   "v1.EndpointSubset": {
-    "id": "v1.EndpointSubset",
-    "properties": {
-     "addresses": {
-      "type": "array",
-      "items": {
-       "$ref": "v1.EndpointAddress"
-      },
-      "description": "IP addresses which offer the related ports"
-     },
-     "ports": {
-      "type": "array",
-      "items": {
-       "$ref": "v1.EndpointPort"
-      },
-      "description": "port numbers available on the related IP addresses"
-     }
-    }
-   },
-   "v1.EndpointAddress": {
-    "id": "v1.EndpointAddress",
+   "v1.PodSpec": {
+    "id": "v1.PodSpec",
     "required": [
-     "ip"
+     "containers"
     ],
     "properties": {
-     "ip": {
-      "type": "string",
-      "description": "IP address of the endpoint"
+     "volumes": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.Volume"
+      },
+      "description": "list of volumes that can be mounted by containers belonging to the pod"
      },
-     "targetRef": {
-      "$ref": "v1.ObjectReference",
-      "description": "reference to object providing the endpoint"
+     "containers": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.Container"
+      },
+      "description": "list of containers belonging to the pod; cannot be updated; containers cannot currently be added or removed; there must be at least one container in a Pod"
+     },
+     "restartPolicy": {
+      "type": "string",
+      "description": "restart policy for all containers within the pod; one of Always, OnFailure, Never; defaults to Always"
+     },
+     "terminationGracePeriodSeconds": {
+      "type": "integer",
+      "format": "int64",
+      "description": "optional duration in seconds the pod needs to terminate gracefully; may be decreased in delete request; value must be non-negative integer; the value zero indicates delete immediately; if this value is not set, the default grace period will be used instead; the grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal; set this value longer than the expected cleanup time for your process"
+     },
+     "activeDeadlineSeconds": {
+      "type": "integer",
+      "format": "int64"
+     },
+     "dnsPolicy": {
+      "type": "string",
+      "description": "DNS policy for containers within the pod; one of 'ClusterFirst' or 'Default'"
+     },
+     "nodeSelector": {
+      "type": "any",
+      "description": "selector which must match a node's labels for the pod to be scheduled on that node"
+     },
+     "serviceAccount": {
+      "type": "string",
+      "description": "name of the ServiceAccount to use to run this pod"
+     },
+     "nodeName": {
+      "type": "string",
+      "description": "node requested for this pod"
+     },
+     "hostNetwork": {
+      "type": "boolean",
+      "description": "host networking requested for this pod"
+     },
+     "imagePullSecrets": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.LocalObjectReference"
+      },
+      "description": "list of references to secrets in the same namespace available for pulling the container images"
      }
     }
    },
-   "v1.EndpointPort": {
-    "id": "v1.EndpointPort",
+   "v1.Volume": {
+    "id": "v1.Volume",
     "required": [
-     "port"
+     "name"
     ],
     "properties": {
      "name": {
       "type": "string",
-      "description": "name of this port"
+      "description": "volume name; must be a DNS_LABEL and unique within the pod"
      },
-     "port": {
+     "hostPath": {
+      "$ref": "v1.HostPathVolumeSource",
+      "description": "pre-existing host file or directory; generally for privileged system daemons or other agents tied to the host"
+     },
+     "emptyDir": {
+      "$ref": "v1.EmptyDirVolumeSource",
+      "description": "temporary directory that shares a pod's lifetime"
+     },
+     "gcePersistentDisk": {
+      "$ref": "v1.GCEPersistentDiskVolumeSource",
+      "description": "GCE disk resource attached to the host machine on demand"
+     },
+     "awsElasticBlockStore": {
+      "$ref": "v1.AWSElasticBlockStoreVolumeSource",
+      "description": "AWS disk resource attached to the host machine on demand"
+     },
+     "gitRepo": {
+      "$ref": "v1.GitRepoVolumeSource",
+      "description": "git repository at a particular revision"
+     },
+     "secret": {
+      "$ref": "v1.SecretVolumeSource",
+      "description": "secret to populate volume"
+     },
+     "nfs": {
+      "$ref": "v1.NFSVolumeSource",
+      "description": "NFS volume that will be mounted in the host machine"
+     },
+     "iscsi": {
+      "$ref": "v1.ISCSIVolumeSource",
+      "description": "iSCSI disk attached to host machine on demand"
+     },
+     "glusterfs": {
+      "$ref": "v1.GlusterfsVolumeSource",
+      "description": "Glusterfs volume that will be mounted on the host machine "
+     },
+     "persistentVolumeClaim": {
+      "$ref": "v1.PersistentVolumeClaimVolumeSource",
+      "description": "a reference to a PersistentVolumeClaim in the same namespace"
+     },
+     "rbd": {
+      "$ref": "v1.RBDVolumeSource",
+      "description": "rados block volume that will be mounted on the host machine"
+     }
+    }
+   },
+   "v1.HostPathVolumeSource": {
+    "id": "v1.HostPathVolumeSource",
+    "required": [
+     "path"
+    ],
+    "properties": {
+     "path": {
+      "type": "string",
+      "description": "path of the directory on the host"
+     }
+    }
+   },
+   "v1.EmptyDirVolumeSource": {
+    "id": "v1.EmptyDirVolumeSource",
+    "properties": {
+     "medium": {
+      "type": "string",
+      "description": "type of storage used to back the volume; must be an empty string (default) or Memory"
+     }
+    }
+   },
+   "v1.GCEPersistentDiskVolumeSource": {
+    "id": "v1.GCEPersistentDiskVolumeSource",
+    "required": [
+     "pdName",
+     "fsType"
+    ],
+    "properties": {
+     "pdName": {
+      "type": "string",
+      "description": "unique name of the PD resource in GCE"
+     },
+     "fsType": {
+      "type": "string",
+      "description": "file system type to mount, such as ext4, xfs, ntfs"
+     },
+     "partition": {
       "type": "integer",
       "format": "int32",
-      "description": "port number of the endpoint"
+      "description": "partition on the disk to mount (e.g., '1' for /dev/sda1); if omitted the plain device name (e.g., /dev/sda) will be mounted"
+     },
+     "readOnly": {
+      "type": "boolean",
+      "description": "read-only if true, read-write otherwise (false or unspecified)"
+     }
+    }
+   },
+   "v1.AWSElasticBlockStoreVolumeSource": {
+    "id": "v1.AWSElasticBlockStoreVolumeSource",
+    "required": [
+     "volumeID",
+     "fsType"
+    ],
+    "properties": {
+     "volumeID": {
+      "type": "string",
+      "description": "unique id of the PD resource in AWS"
+     },
+     "fsType": {
+      "type": "string",
+      "description": "file system type to mount, such as ext4, xfs, ntfs"
+     },
+     "partition": {
+      "type": "integer",
+      "format": "int32",
+      "description": "partition on the disk to mount (e.g., '1' for /dev/sda1); if omitted the plain device name (e.g., /dev/sda) will be mounted"
+     },
+     "readOnly": {
+      "type": "boolean",
+      "description": "read-only if true, read-write otherwise (false or unspecified)"
+     }
+    }
+   },
+   "v1.GitRepoVolumeSource": {
+    "id": "v1.GitRepoVolumeSource",
+    "required": [
+     "repository",
+     "revision"
+    ],
+    "properties": {
+     "repository": {
+      "type": "string",
+      "description": "repository URL"
+     },
+     "revision": {
+      "type": "string",
+      "description": "commit hash for the specified revision"
+     }
+    }
+   },
+   "v1.SecretVolumeSource": {
+    "id": "v1.SecretVolumeSource",
+    "required": [
+     "secretName"
+    ],
+    "properties": {
+     "secretName": {
+      "type": "string",
+      "description": "secretName is the name of a secret in the pod's namespace"
+     }
+    }
+   },
+   "v1.NFSVolumeSource": {
+    "id": "v1.NFSVolumeSource",
+    "required": [
+     "server",
+     "path"
+    ],
+    "properties": {
+     "server": {
+      "type": "string",
+      "description": "the hostname or IP address of the NFS server"
+     },
+     "path": {
+      "type": "string",
+      "description": "the path that is exported by the NFS server"
+     },
+     "readOnly": {
+      "type": "boolean",
+      "description": "forces the NFS export to be mounted with read-only permissions"
+     }
+    }
+   },
+   "v1.ISCSIVolumeSource": {
+    "id": "v1.ISCSIVolumeSource",
+    "required": [
+     "targetPortal",
+     "iqn",
+     "lun",
+     "fsType"
+    ],
+    "properties": {
+     "targetPortal": {
+      "type": "string",
+      "description": "iSCSI target portal"
+     },
+     "iqn": {
+      "type": "string",
+      "description": "iSCSI Qualified Name"
+     },
+     "lun": {
+      "type": "integer",
+      "format": "int32",
+      "description": "iscsi target lun number"
+     },
+     "fsType": {
+      "type": "string",
+      "description": "file system type to mount, such as ext4, xfs, ntfs"
+     },
+     "readOnly": {
+      "type": "boolean",
+      "description": "read-only if true, read-write otherwise (false or unspecified)"
+     }
+    }
+   },
+   "v1.GlusterfsVolumeSource": {
+    "id": "v1.GlusterfsVolumeSource",
+    "required": [
+     "endpoints",
+     "path"
+    ],
+    "properties": {
+     "endpoints": {
+      "type": "string",
+      "description": "gluster hosts endpoints name"
+     },
+     "path": {
+      "type": "string",
+      "description": "path to gluster volume"
+     },
+     "readOnly": {
+      "type": "boolean",
+      "description": "glusterfs volume to be mounted with read-only permissions"
+     }
+    }
+   },
+   "v1.PersistentVolumeClaimVolumeSource": {
+    "id": "v1.PersistentVolumeClaimVolumeSource",
+    "required": [
+     "claimName"
+    ],
+    "properties": {
+     "claimName": {
+      "type": "string",
+      "description": "the name of the claim in the same namespace to be mounted as a volume"
+     },
+     "readOnly": {
+      "type": "boolean",
+      "description": "mount volume as read-only when true; default false"
+     }
+    }
+   },
+   "v1.RBDVolumeSource": {
+    "id": "v1.RBDVolumeSource",
+    "required": [
+     "monitors",
+     "image",
+     "pool",
+     "user",
+     "keyring",
+     "secretRef"
+    ],
+    "properties": {
+     "monitors": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "a collection of Ceph monitors"
+     },
+     "image": {
+      "type": "string",
+      "description": "rados image name"
+     },
+     "fsType": {
+      "type": "string",
+      "description": "file system type to mount, such as ext4, xfs, ntfs"
+     },
+     "pool": {
+      "type": "string",
+      "description": "rados pool name; default is rbd; optional"
+     },
+     "user": {
+      "type": "string",
+      "description": "rados user name; default is admin; optional"
+     },
+     "keyring": {
+      "type": "string",
+      "description": "keyring is the path to key ring for rados user; default is /etc/ceph/keyring; optional"
+     },
+     "secretRef": {
+      "$ref": "v1.LocalObjectReference",
+      "description": "name of a secret to authenticate the RBD user; if provided overrides keyring; optional"
+     },
+     "readOnly": {
+      "type": "boolean",
+      "description": "rbd volume to be mounted with read-only permissions"
+     }
+    }
+   },
+   "v1.LocalObjectReference": {
+    "id": "v1.LocalObjectReference",
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "name of the referent"
+     }
+    }
+   },
+   "v1.Container": {
+    "id": "v1.Container",
+    "required": [
+     "name"
+    ],
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "name of the container; must be a DNS_LABEL and unique within the pod; cannot be updated"
+     },
+     "image": {
+      "type": "string",
+      "description": "Docker image name"
+     },
+     "command": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "entrypoint array; not executed within a shell; the docker image's entrypoint is used if this is not provided; cannot be updated; variable references $(VAR_NAME) are expanded using the container's environment variables; if a variable cannot be resolved, the reference in the input string will be unchanged; the $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME) ; escaped references will never be expanded, regardless of whether the variable exists or not"
+     },
+     "args": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "command array; the docker image's cmd is used if this is not provided; arguments to the entrypoint; cannot be updated; variable references $(VAR_NAME) are expanded using the container's environment variables; if a variable cannot be resolved, the reference in the input string will be unchanged; the $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME) ; escaped references will never be expanded, regardless of whether the variable exists or not"
+     },
+     "workingDir": {
+      "type": "string",
+      "description": "container's working directory; defaults to image's default; cannot be updated"
+     },
+     "ports": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.ContainerPort"
+      },
+      "description": "list of ports to expose from the container; cannot be updated"
+     },
+     "env": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.EnvVar"
+      },
+      "description": "list of environment variables to set in the container; cannot be updated"
+     },
+     "resources": {
+      "$ref": "v1.ResourceRequirements",
+      "description": "Compute Resources required by this container; cannot be updated"
+     },
+     "volumeMounts": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.VolumeMount"
+      },
+      "description": "pod volumes to mount into the container's filesyste; cannot be updated"
+     },
+     "livenessProbe": {
+      "$ref": "v1.Probe",
+      "description": "periodic probe of container liveness; container will be restarted if the probe fails; cannot be updated"
+     },
+     "readinessProbe": {
+      "$ref": "v1.Probe",
+      "description": "periodic probe of container service readiness; container will be removed from service endpoints if the probe fails; cannot be updated"
+     },
+     "lifecycle": {
+      "$ref": "v1.Lifecycle",
+      "description": "actions that the management system should take in response to container lifecycle events; cannot be updated"
+     },
+     "terminationMessagePath": {
+      "type": "string",
+      "description": "path at which the file to which the container's termination message will be written is mounted into the container's filesystem; message written is intended to be brief final status, such as an assertion failure message; defaults to /dev/termination-log; cannot be updated"
+     },
+     "imagePullPolicy": {
+      "type": "string",
+      "description": "image pull policy; one of Always, Never, IfNotPresent; defaults to Always if :latest tag is specified, or IfNotPresent otherwise; cannot be updated"
+     },
+     "securityContext": {
+      "$ref": "v1.SecurityContext",
+      "description": "security options the pod should run with"
+     }
+    }
+   },
+   "v1.ContainerPort": {
+    "id": "v1.ContainerPort",
+    "required": [
+     "containerPort"
+    ],
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "name for the port that can be referred to by services; must be a DNS_LABEL and unique without the pod"
+     },
+     "hostPort": {
+      "type": "integer",
+      "format": "int32",
+      "description": "number of port to expose on the host; most containers do not need this"
+     },
+     "containerPort": {
+      "type": "integer",
+      "format": "int32",
+      "description": "number of port to expose on the pod's IP address"
      },
      "protocol": {
       "type": "string",
-      "description": "protocol for this port; must be UDP or TCP; TCP if unspecified"
+      "description": "protocol for port; must be UDP or TCP; TCP if unspecified"
+     },
+     "hostIP": {
+      "type": "string",
+      "description": "host IP to bind the port to"
+     }
+    }
+   },
+   "v1.EnvVar": {
+    "id": "v1.EnvVar",
+    "required": [
+     "name"
+    ],
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "name of the environment variable; must be a C_IDENTIFIER"
+     },
+     "value": {
+      "type": "string",
+      "description": "value of the environment variable; defaults to empty string; variable references $(VAR_NAME) are expanded using the previously defined environment varibles in the container and any service environment variables; if a variable cannot be resolved, the reference in the input string will be unchanged; the $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME) ; escaped references will never be expanded, regardless of whether the variable exists or not"
+     },
+     "valueFrom": {
+      "$ref": "v1.EnvVarSource",
+      "description": "source for the environment variable's value; cannot be used if value is not empty"
+     }
+    }
+   },
+   "v1.EnvVarSource": {
+    "id": "v1.EnvVarSource",
+    "required": [
+     "fieldRef"
+    ],
+    "properties": {
+     "fieldRef": {
+      "$ref": "v1.ObjectFieldSelector",
+      "description": "selects a field of the pod; only name and namespace are supported"
+     }
+    }
+   },
+   "v1.ObjectFieldSelector": {
+    "id": "v1.ObjectFieldSelector",
+    "required": [
+     "fieldPath"
+    ],
+    "properties": {
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema that fieldPath is written in terms of; defaults to v1"
+     },
+     "fieldPath": {
+      "type": "string",
+      "description": "path of the field to select in the specified API version"
+     }
+    }
+   },
+   "v1.ResourceRequirements": {
+    "id": "v1.ResourceRequirements",
+    "properties": {
+     "limits": {
+      "type": "any",
+      "description": "Maximum amount of compute resources allowed"
+     },
+     "requests": {
+      "type": "any",
+      "description": "Minimum amount of resources requested; requests are honored only for persistent volumes as of now"
+     }
+    }
+   },
+   "v1.VolumeMount": {
+    "id": "v1.VolumeMount",
+    "required": [
+     "name",
+     "mountPath"
+    ],
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "name of the volume to mount"
+     },
+     "readOnly": {
+      "type": "boolean",
+      "description": "mounted read-only if true, read-write otherwise (false or unspecified)"
+     },
+     "mountPath": {
+      "type": "string",
+      "description": "path within the container at which the volume should be mounted"
+     }
+    }
+   },
+   "v1.Probe": {
+    "id": "v1.Probe",
+    "properties": {
+     "exec": {
+      "$ref": "v1.ExecAction",
+      "description": "exec-based handler"
+     },
+     "httpGet": {
+      "$ref": "v1.HTTPGetAction",
+      "description": "HTTP-based handler"
+     },
+     "tcpSocket": {
+      "$ref": "v1.TCPSocketAction",
+      "description": "TCP-based handler; TCP hooks not yet supported"
+     },
+     "initialDelaySeconds": {
+      "type": "integer",
+      "format": "int64",
+      "description": "number of seconds after the container has started before liveness probes are initiated"
+     },
+     "timeoutSeconds": {
+      "type": "integer",
+      "format": "int64",
+      "description": "number of seconds after which liveness probes timeout; defaults to 1 second"
+     }
+    }
+   },
+   "v1.ExecAction": {
+    "id": "v1.ExecAction",
+    "properties": {
+     "command": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "command line to execute inside the container; working directory for the command is root ('/') in the container's file system; the command is exec'd, not run inside a shell; exit status of 0 is treated as live/healthy and non-zero is unhealthy"
+     }
+    }
+   },
+   "v1.HTTPGetAction": {
+    "id": "v1.HTTPGetAction",
+    "required": [
+     "port"
+    ],
+    "properties": {
+     "path": {
+      "type": "string",
+      "description": "path to access on the HTTP server"
+     },
+     "port": {
+      "type": "string",
+      "description": "number or name of the port to access on the container"
+     },
+     "host": {
+      "type": "string",
+      "description": "hostname to connect to; defaults to pod IP"
+     }
+    }
+   },
+   "v1.TCPSocketAction": {
+    "id": "v1.TCPSocketAction",
+    "required": [
+     "port"
+    ],
+    "properties": {
+     "port": {
+      "type": "string",
+      "description": "number of name of the port to access on the container"
+     }
+    }
+   },
+   "v1.Lifecycle": {
+    "id": "v1.Lifecycle",
+    "properties": {
+     "postStart": {
+      "$ref": "v1.Handler",
+      "description": "called immediately after a container is started; if the handler fails, the container is terminated and restarted according to its restart policy; other management of the container blocks until the hook completes"
+     },
+     "preStop": {
+      "$ref": "v1.Handler",
+      "description": "called before a container is terminated; the container is terminated after the handler completes; other management of the container blocks until the hook completes"
+     }
+    }
+   },
+   "v1.Handler": {
+    "id": "v1.Handler",
+    "properties": {
+     "exec": {
+      "$ref": "v1.ExecAction",
+      "description": "exec-based handler"
+     },
+     "httpGet": {
+      "$ref": "v1.HTTPGetAction",
+      "description": "HTTP-based handler"
+     },
+     "tcpSocket": {
+      "$ref": "v1.TCPSocketAction",
+      "description": "TCP-based handler; TCP hooks not yet supported"
+     }
+    }
+   },
+   "v1.SecurityContext": {
+    "id": "v1.SecurityContext",
+    "properties": {
+     "capabilities": {
+      "$ref": "v1.Capabilities",
+      "description": "the linux capabilites that should be added or removed"
+     },
+     "privileged": {
+      "type": "boolean",
+      "description": "run the container in privileged mode"
+     },
+     "seLinuxOptions": {
+      "$ref": "v1.SELinuxOptions",
+      "description": "options that control the SELinux labels applied"
+     },
+     "runAsUser": {
+      "type": "integer",
+      "format": "int64",
+      "description": "the user id that runs the first process in the container"
+     }
+    }
+   },
+   "v1.Capabilities": {
+    "id": "v1.Capabilities",
+    "properties": {
+     "add": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.Capability"
+      },
+      "description": "added capabilities"
+     },
+     "drop": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.Capability"
+      },
+      "description": "droped capabilities"
+     }
+    }
+   },
+   "v1.Capability": {
+    "id": "v1.Capability",
+    "properties": {}
+   },
+   "v1.SELinuxOptions": {
+    "id": "v1.SELinuxOptions",
+    "properties": {
+     "user": {
+      "type": "string",
+      "description": "the user label to apply to the container"
+     },
+     "role": {
+      "type": "string",
+      "description": "the role label to apply to the container"
+     },
+     "type": {
+      "type": "string",
+      "description": "the type label to apply to the container"
+     },
+     "level": {
+      "type": "string",
+      "description": "the level label to apply to the container"
+     }
+    }
+   },
+   "v1.DaemonControllerStatus": {
+    "id": "v1.DaemonControllerStatus",
+    "required": [
+     "nodes_running_daemon",
+     "nodes_should_run_daemon"
+    ],
+    "properties": {
+     "nodes_running_daemon": {
+      "type": "integer",
+      "format": "int32"
+     },
+     "nodes_should_run_daemon": {
+      "type": "integer",
+      "format": "int32"
      }
     }
    },
@@ -11128,6 +12493,116 @@
       "type": "integer",
       "format": "int64",
       "description": "the duration in seconds to wait before deleting this object; defaults to a per object value if not specified; zero means delete immediately"
+     }
+    }
+   },
+   "v1.EndpointsList": {
+    "id": "v1.EndpointsList",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase; cannot be updated"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have"
+     },
+     "metadata": {
+      "$ref": "v1.ListMeta",
+      "description": "standard list metadata; see http://docs.k8s.io/api-conventions.md#metadata"
+     },
+     "items": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.Endpoints"
+      },
+      "description": "list of endpoints"
+     }
+    }
+   },
+   "v1.Endpoints": {
+    "id": "v1.Endpoints",
+    "required": [
+     "subsets"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase; cannot be updated"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have"
+     },
+     "metadata": {
+      "$ref": "v1.ObjectMeta",
+      "description": "standard object metadata; see http://docs.k8s.io/api-conventions.md#metadata"
+     },
+     "subsets": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.EndpointSubset"
+      },
+      "description": "sets of addresses and ports that comprise a service"
+     }
+    }
+   },
+   "v1.EndpointSubset": {
+    "id": "v1.EndpointSubset",
+    "properties": {
+     "addresses": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.EndpointAddress"
+      },
+      "description": "IP addresses which offer the related ports"
+     },
+     "ports": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.EndpointPort"
+      },
+      "description": "port numbers available on the related IP addresses"
+     }
+    }
+   },
+   "v1.EndpointAddress": {
+    "id": "v1.EndpointAddress",
+    "required": [
+     "ip"
+    ],
+    "properties": {
+     "ip": {
+      "type": "string",
+      "description": "IP address of the endpoint"
+     },
+     "targetRef": {
+      "$ref": "v1.ObjectReference",
+      "description": "reference to object providing the endpoint"
+     }
+    }
+   },
+   "v1.EndpointPort": {
+    "id": "v1.EndpointPort",
+    "required": [
+     "port"
+    ],
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "name of this port"
+     },
+     "port": {
+      "type": "integer",
+      "format": "int32",
+      "description": "port number of the endpoint"
+     },
+     "protocol": {
+      "type": "string",
+      "description": "protocol for this port; must be UDP or TCP; TCP if unspecified"
      }
     }
    },
@@ -11656,19 +13131,6 @@
     "id": "v1.PersistentVolumeAccessMode",
     "properties": {}
    },
-   "v1.ResourceRequirements": {
-    "id": "v1.ResourceRequirements",
-    "properties": {
-     "limits": {
-      "type": "any",
-      "description": "Maximum amount of compute resources allowed"
-     },
-     "requests": {
-      "type": "any",
-      "description": "Minimum amount of resources requested; requests are honored only for persistent volumes as of now"
-     }
-    }
-   },
    "v1.PersistentVolumeClaimStatus": {
     "id": "v1.PersistentVolumeClaimStatus",
     "properties": {
@@ -11790,201 +13252,6 @@
      }
     }
    },
-   "v1.GCEPersistentDiskVolumeSource": {
-    "id": "v1.GCEPersistentDiskVolumeSource",
-    "required": [
-     "pdName",
-     "fsType"
-    ],
-    "properties": {
-     "pdName": {
-      "type": "string",
-      "description": "unique name of the PD resource in GCE"
-     },
-     "fsType": {
-      "type": "string",
-      "description": "file system type to mount, such as ext4, xfs, ntfs"
-     },
-     "partition": {
-      "type": "integer",
-      "format": "int32",
-      "description": "partition on the disk to mount (e.g., '1' for /dev/sda1); if omitted the plain device name (e.g., /dev/sda) will be mounted"
-     },
-     "readOnly": {
-      "type": "boolean",
-      "description": "read-only if true, read-write otherwise (false or unspecified)"
-     }
-    }
-   },
-   "v1.AWSElasticBlockStoreVolumeSource": {
-    "id": "v1.AWSElasticBlockStoreVolumeSource",
-    "required": [
-     "volumeID",
-     "fsType"
-    ],
-    "properties": {
-     "volumeID": {
-      "type": "string",
-      "description": "unique id of the PD resource in AWS"
-     },
-     "fsType": {
-      "type": "string",
-      "description": "file system type to mount, such as ext4, xfs, ntfs"
-     },
-     "partition": {
-      "type": "integer",
-      "format": "int32",
-      "description": "partition on the disk to mount (e.g., '1' for /dev/sda1); if omitted the plain device name (e.g., /dev/sda) will be mounted"
-     },
-     "readOnly": {
-      "type": "boolean",
-      "description": "read-only if true, read-write otherwise (false or unspecified)"
-     }
-    }
-   },
-   "v1.HostPathVolumeSource": {
-    "id": "v1.HostPathVolumeSource",
-    "required": [
-     "path"
-    ],
-    "properties": {
-     "path": {
-      "type": "string",
-      "description": "path of the directory on the host"
-     }
-    }
-   },
-   "v1.GlusterfsVolumeSource": {
-    "id": "v1.GlusterfsVolumeSource",
-    "required": [
-     "endpoints",
-     "path"
-    ],
-    "properties": {
-     "endpoints": {
-      "type": "string",
-      "description": "gluster hosts endpoints name"
-     },
-     "path": {
-      "type": "string",
-      "description": "path to gluster volume"
-     },
-     "readOnly": {
-      "type": "boolean",
-      "description": "glusterfs volume to be mounted with read-only permissions"
-     }
-    }
-   },
-   "v1.NFSVolumeSource": {
-    "id": "v1.NFSVolumeSource",
-    "required": [
-     "server",
-     "path"
-    ],
-    "properties": {
-     "server": {
-      "type": "string",
-      "description": "the hostname or IP address of the NFS server"
-     },
-     "path": {
-      "type": "string",
-      "description": "the path that is exported by the NFS server"
-     },
-     "readOnly": {
-      "type": "boolean",
-      "description": "forces the NFS export to be mounted with read-only permissions"
-     }
-    }
-   },
-   "v1.RBDVolumeSource": {
-    "id": "v1.RBDVolumeSource",
-    "required": [
-     "monitors",
-     "image",
-     "pool",
-     "user",
-     "keyring",
-     "secretRef"
-    ],
-    "properties": {
-     "monitors": {
-      "type": "array",
-      "items": {
-       "type": "string"
-      },
-      "description": "a collection of Ceph monitors"
-     },
-     "image": {
-      "type": "string",
-      "description": "rados image name"
-     },
-     "fsType": {
-      "type": "string",
-      "description": "file system type to mount, such as ext4, xfs, ntfs"
-     },
-     "pool": {
-      "type": "string",
-      "description": "rados pool name; default is rbd; optional"
-     },
-     "user": {
-      "type": "string",
-      "description": "rados user name; default is admin; optional"
-     },
-     "keyring": {
-      "type": "string",
-      "description": "keyring is the path to key ring for rados user; default is /etc/ceph/keyring; optional"
-     },
-     "secretRef": {
-      "$ref": "v1.LocalObjectReference",
-      "description": "name of a secret to authenticate the RBD user; if provided overrides keyring; optional"
-     },
-     "readOnly": {
-      "type": "boolean",
-      "description": "rbd volume to be mounted with read-only permissions"
-     }
-    }
-   },
-   "v1.LocalObjectReference": {
-    "id": "v1.LocalObjectReference",
-    "properties": {
-     "name": {
-      "type": "string",
-      "description": "name of the referent"
-     }
-    }
-   },
-   "v1.ISCSIVolumeSource": {
-    "id": "v1.ISCSIVolumeSource",
-    "required": [
-     "targetPortal",
-     "iqn",
-     "lun",
-     "fsType"
-    ],
-    "properties": {
-     "targetPortal": {
-      "type": "string",
-      "description": "iSCSI target portal"
-     },
-     "iqn": {
-      "type": "string",
-      "description": "iSCSI Qualified Name"
-     },
-     "lun": {
-      "type": "integer",
-      "format": "int32",
-      "description": "iscsi target lun number"
-     },
-     "fsType": {
-      "type": "string",
-      "description": "file system type to mount, such as ext4, xfs, ntfs"
-     },
-     "readOnly": {
-      "type": "boolean",
-      "description": "read-only if true, read-write otherwise (false or unspecified)"
-     }
-    }
-   },
    "v1.PersistentVolumeStatus": {
     "id": "v1.PersistentVolumeStatus",
     "properties": {
@@ -12051,527 +13318,6 @@
      "status": {
       "$ref": "v1.PodStatus",
       "description": "most recently observed status of the pod; populated by the system, read-only; http://docs.k8s.io/api-conventions.md#spec-and-status"
-     }
-    }
-   },
-   "v1.PodSpec": {
-    "id": "v1.PodSpec",
-    "required": [
-     "containers"
-    ],
-    "properties": {
-     "volumes": {
-      "type": "array",
-      "items": {
-       "$ref": "v1.Volume"
-      },
-      "description": "list of volumes that can be mounted by containers belonging to the pod"
-     },
-     "containers": {
-      "type": "array",
-      "items": {
-       "$ref": "v1.Container"
-      },
-      "description": "list of containers belonging to the pod; cannot be updated; containers cannot currently be added or removed; there must be at least one container in a Pod"
-     },
-     "restartPolicy": {
-      "type": "string",
-      "description": "restart policy for all containers within the pod; one of Always, OnFailure, Never; defaults to Always"
-     },
-     "terminationGracePeriodSeconds": {
-      "type": "integer",
-      "format": "int64",
-      "description": "optional duration in seconds the pod needs to terminate gracefully; may be decreased in delete request; value must be non-negative integer; the value zero indicates delete immediately; if this value is not set, the default grace period will be used instead; the grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal; set this value longer than the expected cleanup time for your process"
-     },
-     "activeDeadlineSeconds": {
-      "type": "integer",
-      "format": "int64"
-     },
-     "dnsPolicy": {
-      "type": "string",
-      "description": "DNS policy for containers within the pod; one of 'ClusterFirst' or 'Default'"
-     },
-     "nodeSelector": {
-      "type": "any",
-      "description": "selector which must match a node's labels for the pod to be scheduled on that node"
-     },
-     "serviceAccount": {
-      "type": "string",
-      "description": "name of the ServiceAccount to use to run this pod"
-     },
-     "nodeName": {
-      "type": "string",
-      "description": "node requested for this pod"
-     },
-     "hostNetwork": {
-      "type": "boolean",
-      "description": "host networking requested for this pod"
-     },
-     "imagePullSecrets": {
-      "type": "array",
-      "items": {
-       "$ref": "v1.LocalObjectReference"
-      },
-      "description": "list of references to secrets in the same namespace available for pulling the container images"
-     }
-    }
-   },
-   "v1.Volume": {
-    "id": "v1.Volume",
-    "required": [
-     "name"
-    ],
-    "properties": {
-     "name": {
-      "type": "string",
-      "description": "volume name; must be a DNS_LABEL and unique within the pod"
-     },
-     "hostPath": {
-      "$ref": "v1.HostPathVolumeSource",
-      "description": "pre-existing host file or directory; generally for privileged system daemons or other agents tied to the host"
-     },
-     "emptyDir": {
-      "$ref": "v1.EmptyDirVolumeSource",
-      "description": "temporary directory that shares a pod's lifetime"
-     },
-     "gcePersistentDisk": {
-      "$ref": "v1.GCEPersistentDiskVolumeSource",
-      "description": "GCE disk resource attached to the host machine on demand"
-     },
-     "awsElasticBlockStore": {
-      "$ref": "v1.AWSElasticBlockStoreVolumeSource",
-      "description": "AWS disk resource attached to the host machine on demand"
-     },
-     "gitRepo": {
-      "$ref": "v1.GitRepoVolumeSource",
-      "description": "git repository at a particular revision"
-     },
-     "secret": {
-      "$ref": "v1.SecretVolumeSource",
-      "description": "secret to populate volume"
-     },
-     "nfs": {
-      "$ref": "v1.NFSVolumeSource",
-      "description": "NFS volume that will be mounted in the host machine"
-     },
-     "iscsi": {
-      "$ref": "v1.ISCSIVolumeSource",
-      "description": "iSCSI disk attached to host machine on demand"
-     },
-     "glusterfs": {
-      "$ref": "v1.GlusterfsVolumeSource",
-      "description": "Glusterfs volume that will be mounted on the host machine "
-     },
-     "persistentVolumeClaim": {
-      "$ref": "v1.PersistentVolumeClaimVolumeSource",
-      "description": "a reference to a PersistentVolumeClaim in the same namespace"
-     },
-     "rbd": {
-      "$ref": "v1.RBDVolumeSource",
-      "description": "rados block volume that will be mounted on the host machine"
-     }
-    }
-   },
-   "v1.EmptyDirVolumeSource": {
-    "id": "v1.EmptyDirVolumeSource",
-    "properties": {
-     "medium": {
-      "type": "string",
-      "description": "type of storage used to back the volume; must be an empty string (default) or Memory"
-     }
-    }
-   },
-   "v1.GitRepoVolumeSource": {
-    "id": "v1.GitRepoVolumeSource",
-    "required": [
-     "repository",
-     "revision"
-    ],
-    "properties": {
-     "repository": {
-      "type": "string",
-      "description": "repository URL"
-     },
-     "revision": {
-      "type": "string",
-      "description": "commit hash for the specified revision"
-     }
-    }
-   },
-   "v1.SecretVolumeSource": {
-    "id": "v1.SecretVolumeSource",
-    "required": [
-     "secretName"
-    ],
-    "properties": {
-     "secretName": {
-      "type": "string",
-      "description": "secretName is the name of a secret in the pod's namespace"
-     }
-    }
-   },
-   "v1.PersistentVolumeClaimVolumeSource": {
-    "id": "v1.PersistentVolumeClaimVolumeSource",
-    "required": [
-     "claimName"
-    ],
-    "properties": {
-     "claimName": {
-      "type": "string",
-      "description": "the name of the claim in the same namespace to be mounted as a volume"
-     },
-     "readOnly": {
-      "type": "boolean",
-      "description": "mount volume as read-only when true; default false"
-     }
-    }
-   },
-   "v1.Container": {
-    "id": "v1.Container",
-    "required": [
-     "name"
-    ],
-    "properties": {
-     "name": {
-      "type": "string",
-      "description": "name of the container; must be a DNS_LABEL and unique within the pod; cannot be updated"
-     },
-     "image": {
-      "type": "string",
-      "description": "Docker image name"
-     },
-     "command": {
-      "type": "array",
-      "items": {
-       "type": "string"
-      },
-      "description": "entrypoint array; not executed within a shell; the docker image's entrypoint is used if this is not provided; cannot be updated; variable references $(VAR_NAME) are expanded using the container's environment variables; if a variable cannot be resolved, the reference in the input string will be unchanged; the $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME) ; escaped references will never be expanded, regardless of whether the variable exists or not"
-     },
-     "args": {
-      "type": "array",
-      "items": {
-       "type": "string"
-      },
-      "description": "command array; the docker image's cmd is used if this is not provided; arguments to the entrypoint; cannot be updated; variable references $(VAR_NAME) are expanded using the container's environment variables; if a variable cannot be resolved, the reference in the input string will be unchanged; the $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME) ; escaped references will never be expanded, regardless of whether the variable exists or not"
-     },
-     "workingDir": {
-      "type": "string",
-      "description": "container's working directory; defaults to image's default; cannot be updated"
-     },
-     "ports": {
-      "type": "array",
-      "items": {
-       "$ref": "v1.ContainerPort"
-      },
-      "description": "list of ports to expose from the container; cannot be updated"
-     },
-     "env": {
-      "type": "array",
-      "items": {
-       "$ref": "v1.EnvVar"
-      },
-      "description": "list of environment variables to set in the container; cannot be updated"
-     },
-     "resources": {
-      "$ref": "v1.ResourceRequirements",
-      "description": "Compute Resources required by this container; cannot be updated"
-     },
-     "volumeMounts": {
-      "type": "array",
-      "items": {
-       "$ref": "v1.VolumeMount"
-      },
-      "description": "pod volumes to mount into the container's filesyste; cannot be updated"
-     },
-     "livenessProbe": {
-      "$ref": "v1.Probe",
-      "description": "periodic probe of container liveness; container will be restarted if the probe fails; cannot be updated"
-     },
-     "readinessProbe": {
-      "$ref": "v1.Probe",
-      "description": "periodic probe of container service readiness; container will be removed from service endpoints if the probe fails; cannot be updated"
-     },
-     "lifecycle": {
-      "$ref": "v1.Lifecycle",
-      "description": "actions that the management system should take in response to container lifecycle events; cannot be updated"
-     },
-     "terminationMessagePath": {
-      "type": "string",
-      "description": "path at which the file to which the container's termination message will be written is mounted into the container's filesystem; message written is intended to be brief final status, such as an assertion failure message; defaults to /dev/termination-log; cannot be updated"
-     },
-     "imagePullPolicy": {
-      "type": "string",
-      "description": "image pull policy; one of Always, Never, IfNotPresent; defaults to Always if :latest tag is specified, or IfNotPresent otherwise; cannot be updated"
-     },
-     "securityContext": {
-      "$ref": "v1.SecurityContext",
-      "description": "security options the pod should run with"
-     }
-    }
-   },
-   "v1.ContainerPort": {
-    "id": "v1.ContainerPort",
-    "required": [
-     "containerPort"
-    ],
-    "properties": {
-     "name": {
-      "type": "string",
-      "description": "name for the port that can be referred to by services; must be a DNS_LABEL and unique without the pod"
-     },
-     "hostPort": {
-      "type": "integer",
-      "format": "int32",
-      "description": "number of port to expose on the host; most containers do not need this"
-     },
-     "containerPort": {
-      "type": "integer",
-      "format": "int32",
-      "description": "number of port to expose on the pod's IP address"
-     },
-     "protocol": {
-      "type": "string",
-      "description": "protocol for port; must be UDP or TCP; TCP if unspecified"
-     },
-     "hostIP": {
-      "type": "string",
-      "description": "host IP to bind the port to"
-     }
-    }
-   },
-   "v1.EnvVar": {
-    "id": "v1.EnvVar",
-    "required": [
-     "name"
-    ],
-    "properties": {
-     "name": {
-      "type": "string",
-      "description": "name of the environment variable; must be a C_IDENTIFIER"
-     },
-     "value": {
-      "type": "string",
-      "description": "value of the environment variable; defaults to empty string; variable references $(VAR_NAME) are expanded using the previously defined environment varibles in the container and any service environment variables; if a variable cannot be resolved, the reference in the input string will be unchanged; the $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME) ; escaped references will never be expanded, regardless of whether the variable exists or not"
-     },
-     "valueFrom": {
-      "$ref": "v1.EnvVarSource",
-      "description": "source for the environment variable's value; cannot be used if value is not empty"
-     }
-    }
-   },
-   "v1.EnvVarSource": {
-    "id": "v1.EnvVarSource",
-    "required": [
-     "fieldRef"
-    ],
-    "properties": {
-     "fieldRef": {
-      "$ref": "v1.ObjectFieldSelector",
-      "description": "selects a field of the pod; only name and namespace are supported"
-     }
-    }
-   },
-   "v1.ObjectFieldSelector": {
-    "id": "v1.ObjectFieldSelector",
-    "required": [
-     "fieldPath"
-    ],
-    "properties": {
-     "apiVersion": {
-      "type": "string",
-      "description": "version of the schema that fieldPath is written in terms of; defaults to v1"
-     },
-     "fieldPath": {
-      "type": "string",
-      "description": "path of the field to select in the specified API version"
-     }
-    }
-   },
-   "v1.VolumeMount": {
-    "id": "v1.VolumeMount",
-    "required": [
-     "name",
-     "mountPath"
-    ],
-    "properties": {
-     "name": {
-      "type": "string",
-      "description": "name of the volume to mount"
-     },
-     "readOnly": {
-      "type": "boolean",
-      "description": "mounted read-only if true, read-write otherwise (false or unspecified)"
-     },
-     "mountPath": {
-      "type": "string",
-      "description": "path within the container at which the volume should be mounted"
-     }
-    }
-   },
-   "v1.Probe": {
-    "id": "v1.Probe",
-    "properties": {
-     "exec": {
-      "$ref": "v1.ExecAction",
-      "description": "exec-based handler"
-     },
-     "httpGet": {
-      "$ref": "v1.HTTPGetAction",
-      "description": "HTTP-based handler"
-     },
-     "tcpSocket": {
-      "$ref": "v1.TCPSocketAction",
-      "description": "TCP-based handler; TCP hooks not yet supported"
-     },
-     "initialDelaySeconds": {
-      "type": "integer",
-      "format": "int64",
-      "description": "number of seconds after the container has started before liveness probes are initiated"
-     },
-     "timeoutSeconds": {
-      "type": "integer",
-      "format": "int64",
-      "description": "number of seconds after which liveness probes timeout; defaults to 1 second"
-     }
-    }
-   },
-   "v1.ExecAction": {
-    "id": "v1.ExecAction",
-    "properties": {
-     "command": {
-      "type": "array",
-      "items": {
-       "type": "string"
-      },
-      "description": "command line to execute inside the container; working directory for the command is root ('/') in the container's file system; the command is exec'd, not run inside a shell; exit status of 0 is treated as live/healthy and non-zero is unhealthy"
-     }
-    }
-   },
-   "v1.HTTPGetAction": {
-    "id": "v1.HTTPGetAction",
-    "required": [
-     "port"
-    ],
-    "properties": {
-     "path": {
-      "type": "string",
-      "description": "path to access on the HTTP server"
-     },
-     "port": {
-      "type": "string",
-      "description": "number or name of the port to access on the container"
-     },
-     "host": {
-      "type": "string",
-      "description": "hostname to connect to; defaults to pod IP"
-     }
-    }
-   },
-   "v1.TCPSocketAction": {
-    "id": "v1.TCPSocketAction",
-    "required": [
-     "port"
-    ],
-    "properties": {
-     "port": {
-      "type": "string",
-      "description": "number of name of the port to access on the container"
-     }
-    }
-   },
-   "v1.Lifecycle": {
-    "id": "v1.Lifecycle",
-    "properties": {
-     "postStart": {
-      "$ref": "v1.Handler",
-      "description": "called immediately after a container is started; if the handler fails, the container is terminated and restarted according to its restart policy; other management of the container blocks until the hook completes"
-     },
-     "preStop": {
-      "$ref": "v1.Handler",
-      "description": "called before a container is terminated; the container is terminated after the handler completes; other management of the container blocks until the hook completes"
-     }
-    }
-   },
-   "v1.Handler": {
-    "id": "v1.Handler",
-    "properties": {
-     "exec": {
-      "$ref": "v1.ExecAction",
-      "description": "exec-based handler"
-     },
-     "httpGet": {
-      "$ref": "v1.HTTPGetAction",
-      "description": "HTTP-based handler"
-     },
-     "tcpSocket": {
-      "$ref": "v1.TCPSocketAction",
-      "description": "TCP-based handler; TCP hooks not yet supported"
-     }
-    }
-   },
-   "v1.SecurityContext": {
-    "id": "v1.SecurityContext",
-    "properties": {
-     "capabilities": {
-      "$ref": "v1.Capabilities",
-      "description": "the linux capabilites that should be added or removed"
-     },
-     "privileged": {
-      "type": "boolean",
-      "description": "run the container in privileged mode"
-     },
-     "seLinuxOptions": {
-      "$ref": "v1.SELinuxOptions",
-      "description": "options that control the SELinux labels applied"
-     },
-     "runAsUser": {
-      "type": "integer",
-      "format": "int64",
-      "description": "the user id that runs the first process in the container"
-     }
-    }
-   },
-   "v1.Capabilities": {
-    "id": "v1.Capabilities",
-    "properties": {
-     "add": {
-      "type": "array",
-      "items": {
-       "$ref": "v1.Capability"
-      },
-      "description": "added capabilities"
-     },
-     "drop": {
-      "type": "array",
-      "items": {
-       "$ref": "v1.Capability"
-      },
-      "description": "droped capabilities"
-     }
-    }
-   },
-   "v1.Capability": {
-    "id": "v1.Capability",
-    "properties": {}
-   },
-   "v1.SELinuxOptions": {
-    "id": "v1.SELinuxOptions",
-    "properties": {
-     "user": {
-      "type": "string",
-      "description": "the user label to apply to the container"
-     },
-     "role": {
-      "type": "string",
-      "description": "the role label to apply to the container"
-     },
-     "type": {
-      "type": "string",
-      "description": "the type label to apply to the container"
-     },
-     "level": {
-      "type": "string",
-      "description": "the level label to apply to the container"
      }
     }
    },
@@ -12794,19 +13540,6 @@
      "template": {
       "$ref": "v1.PodTemplateSpec",
       "description": "the template of the desired behavior of the pod; http://docs.k8s.io/api-conventions.md#spec-and-status"
-     }
-    }
-   },
-   "v1.PodTemplateSpec": {
-    "id": "v1.PodTemplateSpec",
-    "properties": {
-     "metadata": {
-      "$ref": "v1.ObjectMeta",
-      "description": "standard object metadata; see http://docs.k8s.io/api-conventions.md#metadata"
-     },
-     "spec": {
-      "$ref": "v1.PodSpec",
-      "description": "specification of the desired behavior of the pod; http://docs.k8s.io/api-conventions.md#spec-and-status"
      }
     }
    },

--- a/api/swagger-spec/v1beta3.json
+++ b/api/swagger-spec/v1beta3.json
@@ -292,6 +292,667 @@
     ]
    },
    {
+    "path": "/api/v1beta3/namespaces/{namespaces}/daemoncontrollers",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.DaemonControllerList",
+      "method": "GET",
+      "summary": "list or watch objects of kind DaemonController",
+      "nickname": "listDaemonController",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "labelSelector",
+        "description": "a selector to restrict the list of returned objects by their labels; defaults to everything",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "fieldSelector",
+        "description": "a selector to restrict the list of returned objects by their fields; defaults to everything",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "watch",
+        "description": "watch for changes to the described resources and return them as a stream of add, update, and remove notifications; specify resourceVersion",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "resourceVersion",
+        "description": "when specified with a watch call, shows changes that occur after that particular version of a resource; defaults to changes from the beginning of history",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespaces",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1beta3.DaemonControllerList"
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "v1beta3.DaemonController",
+      "method": "POST",
+      "summary": "create a DaemonController",
+      "nickname": "createDaemonController",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta3.DaemonController",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespaces",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1beta3.DaemonController"
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/watch/namespaces/{namespaces}/daemoncontrollers",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "json.WatchEvent",
+      "method": "GET",
+      "summary": "watch individual changes to a list of DaemonController",
+      "nickname": "watchDaemonControllerList",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "labelSelector",
+        "description": "a selector to restrict the list of returned objects by their labels; defaults to everything",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "fieldSelector",
+        "description": "a selector to restrict the list of returned objects by their fields; defaults to everything",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "watch",
+        "description": "watch for changes to the described resources and return them as a stream of add, update, and remove notifications; specify resourceVersion",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "resourceVersion",
+        "description": "when specified with a watch call, shows changes that occur after that particular version of a resource; defaults to changes from the beginning of history",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespaces",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "json.WatchEvent"
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/namespaces/{namespaces}/daemoncontrollers/{name}",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.DaemonController",
+      "method": "GET",
+      "summary": "read the specified DaemonController",
+      "nickname": "readDaemonController",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespaces",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the DaemonController",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1beta3.DaemonController"
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "v1beta3.DaemonController",
+      "method": "PUT",
+      "summary": "replace the specified DaemonController",
+      "nickname": "replaceDaemonController",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta3.DaemonController",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespaces",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the DaemonController",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1beta3.DaemonController"
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "v1beta3.DaemonController",
+      "method": "PATCH",
+      "summary": "partially update the specified DaemonController",
+      "nickname": "patchDaemonController",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespaces",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the DaemonController",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "string"
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "application/json-patch+json",
+       "application/merge-patch+json",
+       "application/strategic-merge-patch+json"
+      ]
+     },
+     {
+      "type": "v1beta3.Status",
+      "method": "DELETE",
+      "summary": "delete a DaemonController",
+      "nickname": "deleteDaemonController",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta3.DeleteOptions",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespaces",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the DaemonController",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1beta3.Status"
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/watch/namespaces/{namespaces}/daemoncontrollers/{name}",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "json.WatchEvent",
+      "method": "GET",
+      "summary": "watch changes to an object of kind DaemonController",
+      "nickname": "watchDaemonController",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "labelSelector",
+        "description": "a selector to restrict the list of returned objects by their labels; defaults to everything",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "fieldSelector",
+        "description": "a selector to restrict the list of returned objects by their fields; defaults to everything",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "watch",
+        "description": "watch for changes to the described resources and return them as a stream of add, update, and remove notifications; specify resourceVersion",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "resourceVersion",
+        "description": "when specified with a watch call, shows changes that occur after that particular version of a resource; defaults to changes from the beginning of history",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespaces",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the DaemonController",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "json.WatchEvent"
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/daemoncontrollers",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "v1beta3.DaemonControllerList",
+      "method": "GET",
+      "summary": "list or watch objects of kind DaemonController",
+      "nickname": "listDaemonController",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "labelSelector",
+        "description": "a selector to restrict the list of returned objects by their labels; defaults to everything",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "fieldSelector",
+        "description": "a selector to restrict the list of returned objects by their fields; defaults to everything",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "watch",
+        "description": "watch for changes to the described resources and return them as a stream of add, update, and remove notifications; specify resourceVersion",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "resourceVersion",
+        "description": "when specified with a watch call, shows changes that occur after that particular version of a resource; defaults to changes from the beginning of history",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1beta3.DaemonControllerList"
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "v1beta3.DaemonController",
+      "method": "POST",
+      "summary": "create a DaemonController",
+      "nickname": "createDaemonController",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta3.DaemonController",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1beta3.DaemonController"
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1beta3/watch/daemoncontrollers",
+    "description": "API at /api/v1beta3 version v1beta3",
+    "operations": [
+     {
+      "type": "json.WatchEvent",
+      "method": "GET",
+      "summary": "watch individual changes to a list of DaemonController",
+      "nickname": "watchDaemonControllerList",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "labelSelector",
+        "description": "a selector to restrict the list of returned objects by their labels; defaults to everything",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "fieldSelector",
+        "description": "a selector to restrict the list of returned objects by their fields; defaults to everything",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "watch",
+        "description": "watch for changes to the described resources and return them as a stream of add, update, and remove notifications; specify resourceVersion",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "resourceVersion",
+        "description": "when specified with a watch call, shows changes that occur after that particular version of a resource; defaults to changes from the beginning of history",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "json.WatchEvent"
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
     "path": "/api/v1beta3/namespaces/{namespaces}/endpoints",
     "description": "API at /api/v1beta3 version v1beta3",
     "operations": [
@@ -10907,8 +11568,8 @@
      }
     }
    },
-   "v1beta3.EndpointsList": {
-    "id": "v1beta3.EndpointsList",
+   "v1beta3.DaemonControllerList": {
+    "id": "v1beta3.DaemonControllerList",
     "required": [
      "items"
     ],
@@ -10922,23 +11583,18 @@
       "description": "version of the schema the object should have"
      },
      "metadata": {
-      "$ref": "v1beta3.ListMeta",
-      "description": "standard list metadata; see http://docs.k8s.io/api-conventions.md#metadata"
+      "$ref": "v1beta3.ListMeta"
      },
      "items": {
       "type": "array",
       "items": {
-       "$ref": "v1beta3.Endpoints"
-      },
-      "description": "list of endpoints"
+       "$ref": "v1beta3.DaemonController"
+      }
      }
     }
    },
-   "v1beta3.Endpoints": {
-    "id": "v1beta3.Endpoints",
-    "required": [
-     "subsets"
-    ],
+   "v1beta3.DaemonController": {
+    "id": "v1beta3.DaemonController",
     "properties": {
      "kind": {
       "type": "string",
@@ -10949,71 +11605,785 @@
       "description": "version of the schema the object should have"
      },
      "metadata": {
+      "$ref": "v1beta3.ObjectMeta"
+     },
+     "spec": {
+      "$ref": "v1beta3.DaemonControllerSpec"
+     },
+     "status": {
+      "$ref": "v1beta3.DaemonControllerStatus"
+     }
+    }
+   },
+   "v1beta3.DaemonControllerSpec": {
+    "id": "v1beta3.DaemonControllerSpec",
+    "properties": {
+     "template": {
+      "$ref": "v1beta3.PodTemplateSpec"
+     }
+    }
+   },
+   "v1beta3.PodTemplateSpec": {
+    "id": "v1beta3.PodTemplateSpec",
+    "properties": {
+     "metadata": {
       "$ref": "v1beta3.ObjectMeta",
       "description": "standard object metadata; see http://docs.k8s.io/api-conventions.md#metadata"
      },
-     "subsets": {
-      "type": "array",
-      "items": {
-       "$ref": "v1beta3.EndpointSubset"
-      },
-      "description": "sets of addresses and ports that comprise a service"
+     "spec": {
+      "$ref": "v1beta3.PodSpec",
+      "description": "specification of the desired behavior of the pod; http://docs.k8s.io/api-conventions.md#spec-and-status"
      }
     }
    },
-   "v1beta3.EndpointSubset": {
-    "id": "v1beta3.EndpointSubset",
-    "properties": {
-     "addresses": {
-      "type": "array",
-      "items": {
-       "$ref": "v1beta3.EndpointAddress"
-      },
-      "description": "IP addresses which offer the related ports"
-     },
-     "ports": {
-      "type": "array",
-      "items": {
-       "$ref": "v1beta3.EndpointPort"
-      },
-      "description": "port numbers available on the related IP addresses"
-     }
-    }
-   },
-   "v1beta3.EndpointAddress": {
-    "id": "v1beta3.EndpointAddress",
+   "v1beta3.PodSpec": {
+    "id": "v1beta3.PodSpec",
     "required": [
-     "IP"
+     "containers"
     ],
     "properties": {
-     "IP": {
-      "type": "string",
-      "description": "IP address of the endpoint"
+     "volumes": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta3.Volume"
+      },
+      "description": "list of volumes that can be mounted by containers belonging to the pod"
      },
-     "targetRef": {
-      "$ref": "v1beta3.ObjectReference",
-      "description": "reference to object providing the endpoint"
+     "containers": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta3.Container"
+      },
+      "description": "list of containers belonging to the pod; cannot be updated; containers cannot currently be added or removed; there must be at least one container in a Pod"
+     },
+     "restartPolicy": {
+      "type": "string",
+      "description": "restart policy for all containers within the pod; one of Always, OnFailure, Never; defaults to Always"
+     },
+     "terminationGracePeriodSeconds": {
+      "type": "integer",
+      "format": "int64",
+      "description": "optional duration in seconds the pod needs to terminate gracefully; may be decreased in delete request; value must be non-negative integer; the value zero indicates delete immediately; if this value is not set, the default grace period will be used instead; the grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal; set this value longer than the expected cleanup time for your process"
+     },
+     "activeDeadlineSeconds": {
+      "type": "integer",
+      "format": "int64"
+     },
+     "dnsPolicy": {
+      "type": "string",
+      "description": "DNS policy for containers within the pod; one of 'ClusterFirst' or 'Default'"
+     },
+     "nodeSelector": {
+      "type": "any",
+      "description": "selector which must match a node's labels for the pod to be scheduled on that node"
+     },
+     "serviceAccount": {
+      "type": "string",
+      "description": "name of the ServiceAccount to use to run this pod"
+     },
+     "host": {
+      "type": "string",
+      "description": "host requested for this pod"
+     },
+     "hostNetwork": {
+      "type": "boolean",
+      "description": "host networking requested for this pod"
+     },
+     "imagePullSecrets": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta3.LocalObjectReference"
+      },
+      "description": "list of references to secrets in the same namespace available for pulling the container images"
      }
     }
    },
-   "v1beta3.EndpointPort": {
-    "id": "v1beta3.EndpointPort",
+   "v1beta3.Volume": {
+    "id": "v1beta3.Volume",
     "required": [
-     "port"
+     "name"
     ],
     "properties": {
      "name": {
       "type": "string",
-      "description": "name of this port"
+      "description": "volume name; must be a DNS_LABEL and unique within the pod"
      },
-     "port": {
+     "hostPath": {
+      "$ref": "v1beta3.HostPathVolumeSource",
+      "description": "pre-existing host file or directory; generally for privileged system daemons or other agents tied to the host"
+     },
+     "emptyDir": {
+      "$ref": "v1beta3.EmptyDirVolumeSource",
+      "description": "temporary directory that shares a pod's lifetime"
+     },
+     "gcePersistentDisk": {
+      "$ref": "v1beta3.GCEPersistentDiskVolumeSource",
+      "description": "GCE disk resource attached to the host machine on demand"
+     },
+     "awsElasticBlockStore": {
+      "$ref": "v1beta3.AWSElasticBlockStoreVolumeSource",
+      "description": "AWS disk resource attached to the host machine on demand"
+     },
+     "gitRepo": {
+      "$ref": "v1beta3.GitRepoVolumeSource",
+      "description": "git repository at a particular revision"
+     },
+     "secret": {
+      "$ref": "v1beta3.SecretVolumeSource",
+      "description": "secret to populate volume"
+     },
+     "nfs": {
+      "$ref": "v1beta3.NFSVolumeSource",
+      "description": "NFS volume that will be mounted in the host machine"
+     },
+     "iscsi": {
+      "$ref": "v1beta3.ISCSIVolumeSource",
+      "description": "iSCSI disk attached to host machine on demand"
+     },
+     "glusterfs": {
+      "$ref": "v1beta3.GlusterfsVolumeSource",
+      "description": "Glusterfs volume that will be mounted on the host machine "
+     },
+     "persistentVolumeClaim": {
+      "$ref": "v1beta3.PersistentVolumeClaimVolumeSource",
+      "description": "a reference to a PersistentVolumeClaim in the same namespace"
+     },
+     "rbd": {
+      "$ref": "v1beta3.RBDVolumeSource",
+      "description": "rados block volume that will be mounted on the host machine"
+     }
+    }
+   },
+   "v1beta3.HostPathVolumeSource": {
+    "id": "v1beta3.HostPathVolumeSource",
+    "required": [
+     "path"
+    ],
+    "properties": {
+     "path": {
+      "type": "string",
+      "description": "path of the directory on the host"
+     }
+    }
+   },
+   "v1beta3.EmptyDirVolumeSource": {
+    "id": "v1beta3.EmptyDirVolumeSource",
+    "properties": {
+     "medium": {
+      "type": "string",
+      "description": "type of storage used to back the volume; must be an empty string (default) or Memory"
+     }
+    }
+   },
+   "v1beta3.GCEPersistentDiskVolumeSource": {
+    "id": "v1beta3.GCEPersistentDiskVolumeSource",
+    "required": [
+     "pdName",
+     "fsType"
+    ],
+    "properties": {
+     "pdName": {
+      "type": "string",
+      "description": "unique name of the PD resource in GCE"
+     },
+     "fsType": {
+      "type": "string",
+      "description": "file system type to mount, such as ext4, xfs, ntfs"
+     },
+     "partition": {
       "type": "integer",
       "format": "int32",
-      "description": "port number of the endpoint"
+      "description": "partition on the disk to mount (e.g., '1' for /dev/sda1); if omitted the plain device name (e.g., /dev/sda) will be mounted"
+     },
+     "readOnly": {
+      "type": "boolean",
+      "description": "read-only if true, read-write otherwise (false or unspecified)"
+     }
+    }
+   },
+   "v1beta3.AWSElasticBlockStoreVolumeSource": {
+    "id": "v1beta3.AWSElasticBlockStoreVolumeSource",
+    "required": [
+     "volumeID",
+     "fsType"
+    ],
+    "properties": {
+     "volumeID": {
+      "type": "string",
+      "description": "unique id of the PD resource in AWS"
+     },
+     "fsType": {
+      "type": "string",
+      "description": "file system type to mount, such as ext4, xfs, ntfs"
+     },
+     "partition": {
+      "type": "integer",
+      "format": "int32",
+      "description": "partition on the disk to mount (e.g., '1' for /dev/sda1); if omitted the plain device name (e.g., /dev/sda) will be mounted"
+     },
+     "readOnly": {
+      "type": "boolean",
+      "description": "read-only if true, read-write otherwise (false or unspecified)"
+     }
+    }
+   },
+   "v1beta3.GitRepoVolumeSource": {
+    "id": "v1beta3.GitRepoVolumeSource",
+    "required": [
+     "repository"
+    ],
+    "properties": {
+     "repository": {
+      "type": "string",
+      "description": "repository URL"
+     },
+     "revision": {
+      "type": "string",
+      "description": "commit hash for the specified revision"
+     }
+    }
+   },
+   "v1beta3.SecretVolumeSource": {
+    "id": "v1beta3.SecretVolumeSource",
+    "required": [
+     "secretName"
+    ],
+    "properties": {
+     "secretName": {
+      "type": "string",
+      "description": "secretName is the name of a secret in the pod's namespace"
+     }
+    }
+   },
+   "v1beta3.NFSVolumeSource": {
+    "id": "v1beta3.NFSVolumeSource",
+    "required": [
+     "server",
+     "path"
+    ],
+    "properties": {
+     "server": {
+      "type": "string",
+      "description": "the hostname or IP address of the NFS server"
+     },
+     "path": {
+      "type": "string",
+      "description": "the path that is exported by the NFS server"
+     },
+     "readOnly": {
+      "type": "boolean",
+      "description": "forces the NFS export to be mounted with read-only permissions"
+     }
+    }
+   },
+   "v1beta3.ISCSIVolumeSource": {
+    "id": "v1beta3.ISCSIVolumeSource",
+    "required": [
+     "targetPortal",
+     "iqn",
+     "lun",
+     "fsType"
+    ],
+    "properties": {
+     "targetPortal": {
+      "type": "string",
+      "description": "iSCSI target portal"
+     },
+     "iqn": {
+      "type": "string",
+      "description": "iSCSI Qualified Name"
+     },
+     "lun": {
+      "type": "integer",
+      "format": "int32",
+      "description": "iscsi target lun number"
+     },
+     "fsType": {
+      "type": "string",
+      "description": "file system type to mount, such as ext4, xfs, ntfs"
+     },
+     "readOnly": {
+      "type": "boolean",
+      "description": "read-only if true, read-write otherwise (false or unspecified)"
+     }
+    }
+   },
+   "v1beta3.GlusterfsVolumeSource": {
+    "id": "v1beta3.GlusterfsVolumeSource",
+    "required": [
+     "endpoints",
+     "path"
+    ],
+    "properties": {
+     "endpoints": {
+      "type": "string",
+      "description": "gluster hosts endpoints name"
+     },
+     "path": {
+      "type": "string",
+      "description": "path to gluster volume"
+     },
+     "readOnly": {
+      "type": "boolean",
+      "description": "glusterfs volume to be mounted with read-only permissions"
+     }
+    }
+   },
+   "v1beta3.PersistentVolumeClaimVolumeSource": {
+    "id": "v1beta3.PersistentVolumeClaimVolumeSource",
+    "properties": {
+     "claimName": {
+      "type": "string",
+      "description": "the name of the claim in the same namespace to be mounted as a volume"
+     },
+     "readOnly": {
+      "type": "boolean",
+      "description": "mount volume as read-only when true; default false"
+     }
+    }
+   },
+   "v1beta3.RBDVolumeSource": {
+    "id": "v1beta3.RBDVolumeSource",
+    "required": [
+     "monitors",
+     "image",
+     "pool",
+     "user",
+     "keyring",
+     "secretRef"
+    ],
+    "properties": {
+     "monitors": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "a collection of Ceph monitors"
+     },
+     "image": {
+      "type": "string",
+      "description": "rados image name"
+     },
+     "fsType": {
+      "type": "string",
+      "description": "file system type to mount, such as ext4, xfs, ntfs"
+     },
+     "pool": {
+      "type": "string",
+      "description": "rados pool name; default is rbd; optional"
+     },
+     "user": {
+      "type": "string",
+      "description": "rados user name; default is admin; optional"
+     },
+     "keyring": {
+      "type": "string",
+      "description": "keyring is the path to key ring for rados user; default is /etc/ceph/keyring; optional"
+     },
+     "secretRef": {
+      "$ref": "v1beta3.LocalObjectReference",
+      "description": "name of a secret to authenticate the RBD user; if provided overrides keyring; optional"
+     },
+     "readOnly": {
+      "type": "boolean",
+      "description": "rbd volume to be mounted with read-only permissions"
+     }
+    }
+   },
+   "v1beta3.LocalObjectReference": {
+    "id": "v1beta3.LocalObjectReference",
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "name of the referent"
+     }
+    }
+   },
+   "v1beta3.Container": {
+    "id": "v1beta3.Container",
+    "required": [
+     "name",
+     "image"
+    ],
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "name of the container; must be a DNS_LABEL and unique within the pod; cannot be updated"
+     },
+     "image": {
+      "type": "string",
+      "description": "Docker image name"
+     },
+     "command": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "entrypoint array; not executed within a shell; the docker image's entrypoint is used if this is not provided; cannot be updated; variable references $(VAR_NAME) are expanded using the container's environment variables; if a variable cannot be resolved, the reference in the input string will be unchanged; the $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME) ; escaped references will never be expanded, regardless of whether the variable exists or not"
+     },
+     "args": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "command array; the docker image's cmd is used if this is not provided; arguments to the entrypoint; cannot be updated; variable references $(VAR_NAME) are expanded using the container's environment variables; if a variable cannot be resolved, the reference in the input string will be unchanged; the $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME) ; escaped references will never be expanded, regardless of whether the variable exists or not"
+     },
+     "workingDir": {
+      "type": "string",
+      "description": "container's working directory; defaults to image's default; cannot be updated"
+     },
+     "ports": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta3.ContainerPort"
+      },
+      "description": "list of ports to expose from the container; cannot be updated"
+     },
+     "env": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta3.EnvVar"
+      },
+      "description": "list of environment variables to set in the container; cannot be updated"
+     },
+     "resources": {
+      "$ref": "v1beta3.ResourceRequirements",
+      "description": "Compute Resources required by this container; cannot be updated"
+     },
+     "volumeMounts": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta3.VolumeMount"
+      },
+      "description": "pod volumes to mount into the container's filesyste; cannot be updated"
+     },
+     "livenessProbe": {
+      "$ref": "v1beta3.Probe",
+      "description": "periodic probe of container liveness; container will be restarted if the probe fails; cannot be updated"
+     },
+     "readinessProbe": {
+      "$ref": "v1beta3.Probe",
+      "description": "periodic probe of container service readiness; container will be removed from service endpoints if the probe fails; cannot be updated"
+     },
+     "lifecycle": {
+      "$ref": "v1beta3.Lifecycle",
+      "description": "actions that the management system should take in response to container lifecycle events; cannot be updated"
+     },
+     "terminationMessagePath": {
+      "type": "string",
+      "description": "path at which the file to which the container's termination message will be written is mounted into the container's filesystem; message written is intended to be brief final status, such as an assertion failure message; defaults to /dev/termination-log; cannot be updated"
+     },
+     "privileged": {
+      "type": "boolean",
+      "description": "whether or not the container is granted privileged status; defaults to false; cannot be updated; deprecated;  See SecurityContext."
+     },
+     "imagePullPolicy": {
+      "type": "string",
+      "description": "image pull policy; one of Always, Never, IfNotPresent; defaults to Always if :latest tag is specified, or IfNotPresent otherwise; cannot be updated"
+     },
+     "capabilities": {
+      "$ref": "v1beta3.Capabilities",
+      "description": "capabilities for container; cannot be updated; deprecated; See SecurityContext."
+     },
+     "securityContext": {
+      "$ref": "v1beta3.SecurityContext",
+      "description": "security options the pod should run with"
+     }
+    }
+   },
+   "v1beta3.ContainerPort": {
+    "id": "v1beta3.ContainerPort",
+    "required": [
+     "containerPort"
+    ],
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "name for the port that can be referred to by services; must be a DNS_LABEL and unique without the pod"
+     },
+     "hostPort": {
+      "type": "integer",
+      "format": "int32",
+      "description": "number of port to expose on the host; most containers do not need this"
+     },
+     "containerPort": {
+      "type": "integer",
+      "format": "int32",
+      "description": "number of port to expose on the pod's IP address"
      },
      "protocol": {
       "type": "string",
-      "description": "protocol for this port; must be UDP or TCP; TCP if unspecified"
+      "description": "protocol for port; must be UDP or TCP; TCP if unspecified"
+     },
+     "hostIP": {
+      "type": "string",
+      "description": "host IP to bind the port to"
+     }
+    }
+   },
+   "v1beta3.EnvVar": {
+    "id": "v1beta3.EnvVar",
+    "required": [
+     "name"
+    ],
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "name of the environment variable; must be a C_IDENTIFIER"
+     },
+     "value": {
+      "type": "string",
+      "description": "value of the environment variable; defaults to empty string; variable references $(VAR_NAME) are expanded using the previously defined environment varibles in the container and any service environment variables; if a variable cannot be resolved, the reference in the input string will be unchanged; the $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME) ; escaped references will never be expanded, regardless of whether the variable exists or not"
+     },
+     "valueFrom": {
+      "$ref": "v1beta3.EnvVarSource",
+      "description": "source for the environment variable's value; cannot be used if value is not empty"
+     }
+    }
+   },
+   "v1beta3.EnvVarSource": {
+    "id": "v1beta3.EnvVarSource",
+    "required": [
+     "fieldRef"
+    ],
+    "properties": {
+     "fieldRef": {
+      "$ref": "v1beta3.ObjectFieldSelector",
+      "description": "selects a field of the pod; only name and namespace are supported"
+     }
+    }
+   },
+   "v1beta3.ObjectFieldSelector": {
+    "id": "v1beta3.ObjectFieldSelector",
+    "required": [
+     "fieldPath"
+    ],
+    "properties": {
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema that fieldPath is written in terms of; defaults to v1beta3"
+     },
+     "fieldPath": {
+      "type": "string",
+      "description": "path of the field to select in the specified API version"
+     }
+    }
+   },
+   "v1beta3.ResourceRequirements": {
+    "id": "v1beta3.ResourceRequirements",
+    "properties": {
+     "limits": {
+      "type": "any",
+      "description": "Maximum amount of compute resources allowed"
+     },
+     "requests": {
+      "type": "any",
+      "description": "Minimum amount of resources requested; requests are honored only for persistent volumes as of now"
+     }
+    }
+   },
+   "v1beta3.VolumeMount": {
+    "id": "v1beta3.VolumeMount",
+    "required": [
+     "name",
+     "mountPath"
+    ],
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "name of the volume to mount"
+     },
+     "readOnly": {
+      "type": "boolean",
+      "description": "mounted read-only if true, read-write otherwise (false or unspecified)"
+     },
+     "mountPath": {
+      "type": "string",
+      "description": "path within the container at which the volume should be mounted"
+     }
+    }
+   },
+   "v1beta3.Probe": {
+    "id": "v1beta3.Probe",
+    "properties": {
+     "exec": {
+      "$ref": "v1beta3.ExecAction",
+      "description": "exec-based handler"
+     },
+     "httpGet": {
+      "$ref": "v1beta3.HTTPGetAction",
+      "description": "HTTP-based handler"
+     },
+     "tcpSocket": {
+      "$ref": "v1beta3.TCPSocketAction",
+      "description": "TCP-based handler; TCP hooks not yet supported"
+     },
+     "initialDelaySeconds": {
+      "type": "integer",
+      "format": "int64",
+      "description": "number of seconds after the container has started before liveness probes are initiated"
+     },
+     "timeoutSeconds": {
+      "type": "integer",
+      "format": "int64",
+      "description": "number of seconds after which liveness probes timeout; defaults to 1 second"
+     }
+    }
+   },
+   "v1beta3.ExecAction": {
+    "id": "v1beta3.ExecAction",
+    "properties": {
+     "command": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "command line to execute inside the container; working directory for the command is root ('/') in the container's file system; the command is exec'd, not run inside a shell; exit status of 0 is treated as live/healthy and non-zero is unhealthy"
+     }
+    }
+   },
+   "v1beta3.HTTPGetAction": {
+    "id": "v1beta3.HTTPGetAction",
+    "required": [
+     "port"
+    ],
+    "properties": {
+     "path": {
+      "type": "string",
+      "description": "path to access on the HTTP server"
+     },
+     "port": {
+      "type": "string",
+      "description": "number or name of the port to access on the container"
+     },
+     "host": {
+      "type": "string",
+      "description": "hostname to connect to; defaults to pod IP"
+     }
+    }
+   },
+   "v1beta3.TCPSocketAction": {
+    "id": "v1beta3.TCPSocketAction",
+    "required": [
+     "port"
+    ],
+    "properties": {
+     "port": {
+      "type": "string",
+      "description": "number of name of the port to access on the container"
+     }
+    }
+   },
+   "v1beta3.Lifecycle": {
+    "id": "v1beta3.Lifecycle",
+    "properties": {
+     "postStart": {
+      "$ref": "v1beta3.Handler",
+      "description": "called immediately after a container is started; if the handler fails, the container is terminated and restarted according to its restart policy; other management of the container blocks until the hook completes"
+     },
+     "preStop": {
+      "$ref": "v1beta3.Handler",
+      "description": "called before a container is terminated; the container is terminated after the handler completes; other management of the container blocks until the hook completes"
+     }
+    }
+   },
+   "v1beta3.Handler": {
+    "id": "v1beta3.Handler",
+    "properties": {
+     "exec": {
+      "$ref": "v1beta3.ExecAction",
+      "description": "exec-based handler"
+     },
+     "httpGet": {
+      "$ref": "v1beta3.HTTPGetAction",
+      "description": "HTTP-based handler"
+     },
+     "tcpSocket": {
+      "$ref": "v1beta3.TCPSocketAction",
+      "description": "TCP-based handler; TCP hooks not yet supported"
+     }
+    }
+   },
+   "v1beta3.Capabilities": {
+    "id": "v1beta3.Capabilities",
+    "properties": {
+     "add": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta3.Capability"
+      },
+      "description": "added capabilities"
+     },
+     "drop": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta3.Capability"
+      },
+      "description": "droped capabilities"
+     }
+    }
+   },
+   "v1beta3.Capability": {
+    "id": "v1beta3.Capability",
+    "properties": {}
+   },
+   "v1beta3.SecurityContext": {
+    "id": "v1beta3.SecurityContext",
+    "properties": {
+     "capabilities": {
+      "$ref": "v1beta3.Capabilities",
+      "description": "the linux capabilites that should be added or removed"
+     },
+     "privileged": {
+      "type": "boolean",
+      "description": "run the container in privileged mode"
+     },
+     "seLinuxOptions": {
+      "$ref": "v1beta3.SELinuxOptions",
+      "description": "options that control the SELinux labels applied"
+     },
+     "runAsUser": {
+      "type": "integer",
+      "format": "int64",
+      "description": "the user id that runs the first process in the container"
+     }
+    }
+   },
+   "v1beta3.SELinuxOptions": {
+    "id": "v1beta3.SELinuxOptions",
+    "properties": {
+     "user": {
+      "type": "string",
+      "description": "the user label to apply to the container"
+     },
+     "role": {
+      "type": "string",
+      "description": "the role label to apply to the container"
+     },
+     "type": {
+      "type": "string",
+      "description": "the type label to apply to the container"
+     },
+     "level": {
+      "type": "string",
+      "description": "the level label to apply to the container"
+     }
+    }
+   },
+   "v1beta3.DaemonControllerStatus": {
+    "id": "v1beta3.DaemonControllerStatus",
+    "required": [
+     "nodes_running_daemon",
+     "nodes_should_run_daemon"
+    ],
+    "properties": {
+     "nodes_running_daemon": {
+      "type": "integer",
+      "format": "int32"
+     },
+     "nodes_should_run_daemon": {
+      "type": "integer",
+      "format": "int32"
      }
     }
    },
@@ -11125,6 +12495,116 @@
       "type": "integer",
       "format": "int64",
       "description": "the duration in seconds to wait before deleting this object; defaults to a per object value if not specified; zero means delete immediately"
+     }
+    }
+   },
+   "v1beta3.EndpointsList": {
+    "id": "v1beta3.EndpointsList",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase; cannot be updated"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have"
+     },
+     "metadata": {
+      "$ref": "v1beta3.ListMeta",
+      "description": "standard list metadata; see http://docs.k8s.io/api-conventions.md#metadata"
+     },
+     "items": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta3.Endpoints"
+      },
+      "description": "list of endpoints"
+     }
+    }
+   },
+   "v1beta3.Endpoints": {
+    "id": "v1beta3.Endpoints",
+    "required": [
+     "subsets"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase; cannot be updated"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have"
+     },
+     "metadata": {
+      "$ref": "v1beta3.ObjectMeta",
+      "description": "standard object metadata; see http://docs.k8s.io/api-conventions.md#metadata"
+     },
+     "subsets": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta3.EndpointSubset"
+      },
+      "description": "sets of addresses and ports that comprise a service"
+     }
+    }
+   },
+   "v1beta3.EndpointSubset": {
+    "id": "v1beta3.EndpointSubset",
+    "properties": {
+     "addresses": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta3.EndpointAddress"
+      },
+      "description": "IP addresses which offer the related ports"
+     },
+     "ports": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta3.EndpointPort"
+      },
+      "description": "port numbers available on the related IP addresses"
+     }
+    }
+   },
+   "v1beta3.EndpointAddress": {
+    "id": "v1beta3.EndpointAddress",
+    "required": [
+     "IP"
+    ],
+    "properties": {
+     "IP": {
+      "type": "string",
+      "description": "IP address of the endpoint"
+     },
+     "targetRef": {
+      "$ref": "v1beta3.ObjectReference",
+      "description": "reference to object providing the endpoint"
+     }
+    }
+   },
+   "v1beta3.EndpointPort": {
+    "id": "v1beta3.EndpointPort",
+    "required": [
+     "port"
+    ],
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "name of this port"
+     },
+     "port": {
+      "type": "integer",
+      "format": "int32",
+      "description": "port number of the endpoint"
+     },
+     "protocol": {
+      "type": "string",
+      "description": "protocol for this port; must be UDP or TCP; TCP if unspecified"
      }
     }
    },
@@ -11653,19 +13133,6 @@
     "id": "v1beta3.PersistentVolumeAccessMode",
     "properties": {}
    },
-   "v1beta3.ResourceRequirements": {
-    "id": "v1beta3.ResourceRequirements",
-    "properties": {
-     "limits": {
-      "type": "any",
-      "description": "Maximum amount of compute resources allowed"
-     },
-     "requests": {
-      "type": "any",
-      "description": "Minimum amount of resources requested; requests are honored only for persistent volumes as of now"
-     }
-    }
-   },
    "v1beta3.PersistentVolumeClaimStatus": {
     "id": "v1beta3.PersistentVolumeClaimStatus",
     "properties": {
@@ -11787,201 +13254,6 @@
      }
     }
    },
-   "v1beta3.GCEPersistentDiskVolumeSource": {
-    "id": "v1beta3.GCEPersistentDiskVolumeSource",
-    "required": [
-     "pdName",
-     "fsType"
-    ],
-    "properties": {
-     "pdName": {
-      "type": "string",
-      "description": "unique name of the PD resource in GCE"
-     },
-     "fsType": {
-      "type": "string",
-      "description": "file system type to mount, such as ext4, xfs, ntfs"
-     },
-     "partition": {
-      "type": "integer",
-      "format": "int32",
-      "description": "partition on the disk to mount (e.g., '1' for /dev/sda1); if omitted the plain device name (e.g., /dev/sda) will be mounted"
-     },
-     "readOnly": {
-      "type": "boolean",
-      "description": "read-only if true, read-write otherwise (false or unspecified)"
-     }
-    }
-   },
-   "v1beta3.AWSElasticBlockStoreVolumeSource": {
-    "id": "v1beta3.AWSElasticBlockStoreVolumeSource",
-    "required": [
-     "volumeID",
-     "fsType"
-    ],
-    "properties": {
-     "volumeID": {
-      "type": "string",
-      "description": "unique id of the PD resource in AWS"
-     },
-     "fsType": {
-      "type": "string",
-      "description": "file system type to mount, such as ext4, xfs, ntfs"
-     },
-     "partition": {
-      "type": "integer",
-      "format": "int32",
-      "description": "partition on the disk to mount (e.g., '1' for /dev/sda1); if omitted the plain device name (e.g., /dev/sda) will be mounted"
-     },
-     "readOnly": {
-      "type": "boolean",
-      "description": "read-only if true, read-write otherwise (false or unspecified)"
-     }
-    }
-   },
-   "v1beta3.HostPathVolumeSource": {
-    "id": "v1beta3.HostPathVolumeSource",
-    "required": [
-     "path"
-    ],
-    "properties": {
-     "path": {
-      "type": "string",
-      "description": "path of the directory on the host"
-     }
-    }
-   },
-   "v1beta3.GlusterfsVolumeSource": {
-    "id": "v1beta3.GlusterfsVolumeSource",
-    "required": [
-     "endpoints",
-     "path"
-    ],
-    "properties": {
-     "endpoints": {
-      "type": "string",
-      "description": "gluster hosts endpoints name"
-     },
-     "path": {
-      "type": "string",
-      "description": "path to gluster volume"
-     },
-     "readOnly": {
-      "type": "boolean",
-      "description": "glusterfs volume to be mounted with read-only permissions"
-     }
-    }
-   },
-   "v1beta3.NFSVolumeSource": {
-    "id": "v1beta3.NFSVolumeSource",
-    "required": [
-     "server",
-     "path"
-    ],
-    "properties": {
-     "server": {
-      "type": "string",
-      "description": "the hostname or IP address of the NFS server"
-     },
-     "path": {
-      "type": "string",
-      "description": "the path that is exported by the NFS server"
-     },
-     "readOnly": {
-      "type": "boolean",
-      "description": "forces the NFS export to be mounted with read-only permissions"
-     }
-    }
-   },
-   "v1beta3.RBDVolumeSource": {
-    "id": "v1beta3.RBDVolumeSource",
-    "required": [
-     "monitors",
-     "image",
-     "pool",
-     "user",
-     "keyring",
-     "secretRef"
-    ],
-    "properties": {
-     "monitors": {
-      "type": "array",
-      "items": {
-       "type": "string"
-      },
-      "description": "a collection of Ceph monitors"
-     },
-     "image": {
-      "type": "string",
-      "description": "rados image name"
-     },
-     "fsType": {
-      "type": "string",
-      "description": "file system type to mount, such as ext4, xfs, ntfs"
-     },
-     "pool": {
-      "type": "string",
-      "description": "rados pool name; default is rbd; optional"
-     },
-     "user": {
-      "type": "string",
-      "description": "rados user name; default is admin; optional"
-     },
-     "keyring": {
-      "type": "string",
-      "description": "keyring is the path to key ring for rados user; default is /etc/ceph/keyring; optional"
-     },
-     "secretRef": {
-      "$ref": "v1beta3.LocalObjectReference",
-      "description": "name of a secret to authenticate the RBD user; if provided overrides keyring; optional"
-     },
-     "readOnly": {
-      "type": "boolean",
-      "description": "rbd volume to be mounted with read-only permissions"
-     }
-    }
-   },
-   "v1beta3.LocalObjectReference": {
-    "id": "v1beta3.LocalObjectReference",
-    "properties": {
-     "name": {
-      "type": "string",
-      "description": "name of the referent"
-     }
-    }
-   },
-   "v1beta3.ISCSIVolumeSource": {
-    "id": "v1beta3.ISCSIVolumeSource",
-    "required": [
-     "targetPortal",
-     "iqn",
-     "lun",
-     "fsType"
-    ],
-    "properties": {
-     "targetPortal": {
-      "type": "string",
-      "description": "iSCSI target portal"
-     },
-     "iqn": {
-      "type": "string",
-      "description": "iSCSI Qualified Name"
-     },
-     "lun": {
-      "type": "integer",
-      "format": "int32",
-      "description": "iscsi target lun number"
-     },
-     "fsType": {
-      "type": "string",
-      "description": "file system type to mount, such as ext4, xfs, ntfs"
-     },
-     "readOnly": {
-      "type": "boolean",
-      "description": "read-only if true, read-write otherwise (false or unspecified)"
-     }
-    }
-   },
    "v1beta3.PersistentVolumeStatus": {
     "id": "v1beta3.PersistentVolumeStatus",
     "properties": {
@@ -12048,532 +13320,6 @@
      "status": {
       "$ref": "v1beta3.PodStatus",
       "description": "most recently observed status of the pod; populated by the system, read-only; http://docs.k8s.io/api-conventions.md#spec-and-status"
-     }
-    }
-   },
-   "v1beta3.PodSpec": {
-    "id": "v1beta3.PodSpec",
-    "required": [
-     "containers"
-    ],
-    "properties": {
-     "volumes": {
-      "type": "array",
-      "items": {
-       "$ref": "v1beta3.Volume"
-      },
-      "description": "list of volumes that can be mounted by containers belonging to the pod"
-     },
-     "containers": {
-      "type": "array",
-      "items": {
-       "$ref": "v1beta3.Container"
-      },
-      "description": "list of containers belonging to the pod; cannot be updated; containers cannot currently be added or removed; there must be at least one container in a Pod"
-     },
-     "restartPolicy": {
-      "type": "string",
-      "description": "restart policy for all containers within the pod; one of Always, OnFailure, Never; defaults to Always"
-     },
-     "terminationGracePeriodSeconds": {
-      "type": "integer",
-      "format": "int64",
-      "description": "optional duration in seconds the pod needs to terminate gracefully; may be decreased in delete request; value must be non-negative integer; the value zero indicates delete immediately; if this value is not set, the default grace period will be used instead; the grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal; set this value longer than the expected cleanup time for your process"
-     },
-     "activeDeadlineSeconds": {
-      "type": "integer",
-      "format": "int64"
-     },
-     "dnsPolicy": {
-      "type": "string",
-      "description": "DNS policy for containers within the pod; one of 'ClusterFirst' or 'Default'"
-     },
-     "nodeSelector": {
-      "type": "any",
-      "description": "selector which must match a node's labels for the pod to be scheduled on that node"
-     },
-     "serviceAccount": {
-      "type": "string",
-      "description": "name of the ServiceAccount to use to run this pod"
-     },
-     "host": {
-      "type": "string",
-      "description": "host requested for this pod"
-     },
-     "hostNetwork": {
-      "type": "boolean",
-      "description": "host networking requested for this pod"
-     },
-     "imagePullSecrets": {
-      "type": "array",
-      "items": {
-       "$ref": "v1beta3.LocalObjectReference"
-      },
-      "description": "list of references to secrets in the same namespace available for pulling the container images"
-     }
-    }
-   },
-   "v1beta3.Volume": {
-    "id": "v1beta3.Volume",
-    "required": [
-     "name"
-    ],
-    "properties": {
-     "name": {
-      "type": "string",
-      "description": "volume name; must be a DNS_LABEL and unique within the pod"
-     },
-     "hostPath": {
-      "$ref": "v1beta3.HostPathVolumeSource",
-      "description": "pre-existing host file or directory; generally for privileged system daemons or other agents tied to the host"
-     },
-     "emptyDir": {
-      "$ref": "v1beta3.EmptyDirVolumeSource",
-      "description": "temporary directory that shares a pod's lifetime"
-     },
-     "gcePersistentDisk": {
-      "$ref": "v1beta3.GCEPersistentDiskVolumeSource",
-      "description": "GCE disk resource attached to the host machine on demand"
-     },
-     "awsElasticBlockStore": {
-      "$ref": "v1beta3.AWSElasticBlockStoreVolumeSource",
-      "description": "AWS disk resource attached to the host machine on demand"
-     },
-     "gitRepo": {
-      "$ref": "v1beta3.GitRepoVolumeSource",
-      "description": "git repository at a particular revision"
-     },
-     "secret": {
-      "$ref": "v1beta3.SecretVolumeSource",
-      "description": "secret to populate volume"
-     },
-     "nfs": {
-      "$ref": "v1beta3.NFSVolumeSource",
-      "description": "NFS volume that will be mounted in the host machine"
-     },
-     "iscsi": {
-      "$ref": "v1beta3.ISCSIVolumeSource",
-      "description": "iSCSI disk attached to host machine on demand"
-     },
-     "glusterfs": {
-      "$ref": "v1beta3.GlusterfsVolumeSource",
-      "description": "Glusterfs volume that will be mounted on the host machine "
-     },
-     "persistentVolumeClaim": {
-      "$ref": "v1beta3.PersistentVolumeClaimVolumeSource",
-      "description": "a reference to a PersistentVolumeClaim in the same namespace"
-     },
-     "rbd": {
-      "$ref": "v1beta3.RBDVolumeSource",
-      "description": "rados block volume that will be mounted on the host machine"
-     }
-    }
-   },
-   "v1beta3.EmptyDirVolumeSource": {
-    "id": "v1beta3.EmptyDirVolumeSource",
-    "properties": {
-     "medium": {
-      "type": "string",
-      "description": "type of storage used to back the volume; must be an empty string (default) or Memory"
-     }
-    }
-   },
-   "v1beta3.GitRepoVolumeSource": {
-    "id": "v1beta3.GitRepoVolumeSource",
-    "required": [
-     "repository"
-    ],
-    "properties": {
-     "repository": {
-      "type": "string",
-      "description": "repository URL"
-     },
-     "revision": {
-      "type": "string",
-      "description": "commit hash for the specified revision"
-     }
-    }
-   },
-   "v1beta3.SecretVolumeSource": {
-    "id": "v1beta3.SecretVolumeSource",
-    "required": [
-     "secretName"
-    ],
-    "properties": {
-     "secretName": {
-      "type": "string",
-      "description": "secretName is the name of a secret in the pod's namespace"
-     }
-    }
-   },
-   "v1beta3.PersistentVolumeClaimVolumeSource": {
-    "id": "v1beta3.PersistentVolumeClaimVolumeSource",
-    "properties": {
-     "claimName": {
-      "type": "string",
-      "description": "the name of the claim in the same namespace to be mounted as a volume"
-     },
-     "readOnly": {
-      "type": "boolean",
-      "description": "mount volume as read-only when true; default false"
-     }
-    }
-   },
-   "v1beta3.Container": {
-    "id": "v1beta3.Container",
-    "required": [
-     "name",
-     "image"
-    ],
-    "properties": {
-     "name": {
-      "type": "string",
-      "description": "name of the container; must be a DNS_LABEL and unique within the pod; cannot be updated"
-     },
-     "image": {
-      "type": "string",
-      "description": "Docker image name"
-     },
-     "command": {
-      "type": "array",
-      "items": {
-       "type": "string"
-      },
-      "description": "entrypoint array; not executed within a shell; the docker image's entrypoint is used if this is not provided; cannot be updated; variable references $(VAR_NAME) are expanded using the container's environment variables; if a variable cannot be resolved, the reference in the input string will be unchanged; the $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME) ; escaped references will never be expanded, regardless of whether the variable exists or not"
-     },
-     "args": {
-      "type": "array",
-      "items": {
-       "type": "string"
-      },
-      "description": "command array; the docker image's cmd is used if this is not provided; arguments to the entrypoint; cannot be updated; variable references $(VAR_NAME) are expanded using the container's environment variables; if a variable cannot be resolved, the reference in the input string will be unchanged; the $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME) ; escaped references will never be expanded, regardless of whether the variable exists or not"
-     },
-     "workingDir": {
-      "type": "string",
-      "description": "container's working directory; defaults to image's default; cannot be updated"
-     },
-     "ports": {
-      "type": "array",
-      "items": {
-       "$ref": "v1beta3.ContainerPort"
-      },
-      "description": "list of ports to expose from the container; cannot be updated"
-     },
-     "env": {
-      "type": "array",
-      "items": {
-       "$ref": "v1beta3.EnvVar"
-      },
-      "description": "list of environment variables to set in the container; cannot be updated"
-     },
-     "resources": {
-      "$ref": "v1beta3.ResourceRequirements",
-      "description": "Compute Resources required by this container; cannot be updated"
-     },
-     "volumeMounts": {
-      "type": "array",
-      "items": {
-       "$ref": "v1beta3.VolumeMount"
-      },
-      "description": "pod volumes to mount into the container's filesyste; cannot be updated"
-     },
-     "livenessProbe": {
-      "$ref": "v1beta3.Probe",
-      "description": "periodic probe of container liveness; container will be restarted if the probe fails; cannot be updated"
-     },
-     "readinessProbe": {
-      "$ref": "v1beta3.Probe",
-      "description": "periodic probe of container service readiness; container will be removed from service endpoints if the probe fails; cannot be updated"
-     },
-     "lifecycle": {
-      "$ref": "v1beta3.Lifecycle",
-      "description": "actions that the management system should take in response to container lifecycle events; cannot be updated"
-     },
-     "terminationMessagePath": {
-      "type": "string",
-      "description": "path at which the file to which the container's termination message will be written is mounted into the container's filesystem; message written is intended to be brief final status, such as an assertion failure message; defaults to /dev/termination-log; cannot be updated"
-     },
-     "privileged": {
-      "type": "boolean",
-      "description": "whether or not the container is granted privileged status; defaults to false; cannot be updated; deprecated;  See SecurityContext."
-     },
-     "imagePullPolicy": {
-      "type": "string",
-      "description": "image pull policy; one of Always, Never, IfNotPresent; defaults to Always if :latest tag is specified, or IfNotPresent otherwise; cannot be updated"
-     },
-     "capabilities": {
-      "$ref": "v1beta3.Capabilities",
-      "description": "capabilities for container; cannot be updated; deprecated; See SecurityContext."
-     },
-     "securityContext": {
-      "$ref": "v1beta3.SecurityContext",
-      "description": "security options the pod should run with"
-     }
-    }
-   },
-   "v1beta3.ContainerPort": {
-    "id": "v1beta3.ContainerPort",
-    "required": [
-     "containerPort"
-    ],
-    "properties": {
-     "name": {
-      "type": "string",
-      "description": "name for the port that can be referred to by services; must be a DNS_LABEL and unique without the pod"
-     },
-     "hostPort": {
-      "type": "integer",
-      "format": "int32",
-      "description": "number of port to expose on the host; most containers do not need this"
-     },
-     "containerPort": {
-      "type": "integer",
-      "format": "int32",
-      "description": "number of port to expose on the pod's IP address"
-     },
-     "protocol": {
-      "type": "string",
-      "description": "protocol for port; must be UDP or TCP; TCP if unspecified"
-     },
-     "hostIP": {
-      "type": "string",
-      "description": "host IP to bind the port to"
-     }
-    }
-   },
-   "v1beta3.EnvVar": {
-    "id": "v1beta3.EnvVar",
-    "required": [
-     "name"
-    ],
-    "properties": {
-     "name": {
-      "type": "string",
-      "description": "name of the environment variable; must be a C_IDENTIFIER"
-     },
-     "value": {
-      "type": "string",
-      "description": "value of the environment variable; defaults to empty string; variable references $(VAR_NAME) are expanded using the previously defined environment varibles in the container and any service environment variables; if a variable cannot be resolved, the reference in the input string will be unchanged; the $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME) ; escaped references will never be expanded, regardless of whether the variable exists or not"
-     },
-     "valueFrom": {
-      "$ref": "v1beta3.EnvVarSource",
-      "description": "source for the environment variable's value; cannot be used if value is not empty"
-     }
-    }
-   },
-   "v1beta3.EnvVarSource": {
-    "id": "v1beta3.EnvVarSource",
-    "required": [
-     "fieldRef"
-    ],
-    "properties": {
-     "fieldRef": {
-      "$ref": "v1beta3.ObjectFieldSelector",
-      "description": "selects a field of the pod; only name and namespace are supported"
-     }
-    }
-   },
-   "v1beta3.ObjectFieldSelector": {
-    "id": "v1beta3.ObjectFieldSelector",
-    "required": [
-     "fieldPath"
-    ],
-    "properties": {
-     "apiVersion": {
-      "type": "string",
-      "description": "version of the schema that fieldPath is written in terms of; defaults to v1beta3"
-     },
-     "fieldPath": {
-      "type": "string",
-      "description": "path of the field to select in the specified API version"
-     }
-    }
-   },
-   "v1beta3.VolumeMount": {
-    "id": "v1beta3.VolumeMount",
-    "required": [
-     "name",
-     "mountPath"
-    ],
-    "properties": {
-     "name": {
-      "type": "string",
-      "description": "name of the volume to mount"
-     },
-     "readOnly": {
-      "type": "boolean",
-      "description": "mounted read-only if true, read-write otherwise (false or unspecified)"
-     },
-     "mountPath": {
-      "type": "string",
-      "description": "path within the container at which the volume should be mounted"
-     }
-    }
-   },
-   "v1beta3.Probe": {
-    "id": "v1beta3.Probe",
-    "properties": {
-     "exec": {
-      "$ref": "v1beta3.ExecAction",
-      "description": "exec-based handler"
-     },
-     "httpGet": {
-      "$ref": "v1beta3.HTTPGetAction",
-      "description": "HTTP-based handler"
-     },
-     "tcpSocket": {
-      "$ref": "v1beta3.TCPSocketAction",
-      "description": "TCP-based handler; TCP hooks not yet supported"
-     },
-     "initialDelaySeconds": {
-      "type": "integer",
-      "format": "int64",
-      "description": "number of seconds after the container has started before liveness probes are initiated"
-     },
-     "timeoutSeconds": {
-      "type": "integer",
-      "format": "int64",
-      "description": "number of seconds after which liveness probes timeout; defaults to 1 second"
-     }
-    }
-   },
-   "v1beta3.ExecAction": {
-    "id": "v1beta3.ExecAction",
-    "properties": {
-     "command": {
-      "type": "array",
-      "items": {
-       "type": "string"
-      },
-      "description": "command line to execute inside the container; working directory for the command is root ('/') in the container's file system; the command is exec'd, not run inside a shell; exit status of 0 is treated as live/healthy and non-zero is unhealthy"
-     }
-    }
-   },
-   "v1beta3.HTTPGetAction": {
-    "id": "v1beta3.HTTPGetAction",
-    "required": [
-     "port"
-    ],
-    "properties": {
-     "path": {
-      "type": "string",
-      "description": "path to access on the HTTP server"
-     },
-     "port": {
-      "type": "string",
-      "description": "number or name of the port to access on the container"
-     },
-     "host": {
-      "type": "string",
-      "description": "hostname to connect to; defaults to pod IP"
-     }
-    }
-   },
-   "v1beta3.TCPSocketAction": {
-    "id": "v1beta3.TCPSocketAction",
-    "required": [
-     "port"
-    ],
-    "properties": {
-     "port": {
-      "type": "string",
-      "description": "number of name of the port to access on the container"
-     }
-    }
-   },
-   "v1beta3.Lifecycle": {
-    "id": "v1beta3.Lifecycle",
-    "properties": {
-     "postStart": {
-      "$ref": "v1beta3.Handler",
-      "description": "called immediately after a container is started; if the handler fails, the container is terminated and restarted according to its restart policy; other management of the container blocks until the hook completes"
-     },
-     "preStop": {
-      "$ref": "v1beta3.Handler",
-      "description": "called before a container is terminated; the container is terminated after the handler completes; other management of the container blocks until the hook completes"
-     }
-    }
-   },
-   "v1beta3.Handler": {
-    "id": "v1beta3.Handler",
-    "properties": {
-     "exec": {
-      "$ref": "v1beta3.ExecAction",
-      "description": "exec-based handler"
-     },
-     "httpGet": {
-      "$ref": "v1beta3.HTTPGetAction",
-      "description": "HTTP-based handler"
-     },
-     "tcpSocket": {
-      "$ref": "v1beta3.TCPSocketAction",
-      "description": "TCP-based handler; TCP hooks not yet supported"
-     }
-    }
-   },
-   "v1beta3.Capabilities": {
-    "id": "v1beta3.Capabilities",
-    "properties": {
-     "add": {
-      "type": "array",
-      "items": {
-       "$ref": "v1beta3.Capability"
-      },
-      "description": "added capabilities"
-     },
-     "drop": {
-      "type": "array",
-      "items": {
-       "$ref": "v1beta3.Capability"
-      },
-      "description": "droped capabilities"
-     }
-    }
-   },
-   "v1beta3.Capability": {
-    "id": "v1beta3.Capability",
-    "properties": {}
-   },
-   "v1beta3.SecurityContext": {
-    "id": "v1beta3.SecurityContext",
-    "properties": {
-     "capabilities": {
-      "$ref": "v1beta3.Capabilities",
-      "description": "the linux capabilites that should be added or removed"
-     },
-     "privileged": {
-      "type": "boolean",
-      "description": "run the container in privileged mode"
-     },
-     "seLinuxOptions": {
-      "$ref": "v1beta3.SELinuxOptions",
-      "description": "options that control the SELinux labels applied"
-     },
-     "runAsUser": {
-      "type": "integer",
-      "format": "int64",
-      "description": "the user id that runs the first process in the container"
-     }
-    }
-   },
-   "v1beta3.SELinuxOptions": {
-    "id": "v1beta3.SELinuxOptions",
-    "properties": {
-     "user": {
-      "type": "string",
-      "description": "the user label to apply to the container"
-     },
-     "role": {
-      "type": "string",
-      "description": "the role label to apply to the container"
-     },
-     "type": {
-      "type": "string",
-      "description": "the type label to apply to the container"
-     },
-     "level": {
-      "type": "string",
-      "description": "the level label to apply to the container"
      }
     }
    },
@@ -12796,19 +13542,6 @@
      "template": {
       "$ref": "v1beta3.PodTemplateSpec",
       "description": "the template of the desired behavior of the pod; http://docs.k8s.io/api-conventions.md#spec-and-status"
-     }
-    }
-   },
-   "v1beta3.PodTemplateSpec": {
-    "id": "v1beta3.PodTemplateSpec",
-    "properties": {
-     "metadata": {
-      "$ref": "v1beta3.ObjectMeta",
-      "description": "standard object metadata; see http://docs.k8s.io/api-conventions.md#metadata"
-     },
-     "spec": {
-      "$ref": "v1beta3.PodSpec",
-      "description": "specification of the desired behavior of the pod; http://docs.k8s.io/api-conventions.md#spec-and-status"
      }
     }
    },

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -213,7 +213,7 @@ function start_apiserver {
       --admission_control="${ADMISSION_CONTROL}" \
       --address="${API_HOST}" \
       --port="${API_PORT}" \
-      --runtime_config=api/v1beta3 \
+      --runtime_config=api/v1 \
       --etcd_servers="http://127.0.0.1:4001" \
       --service-cluster-ip-range="10.0.0.0/24" \
       --cors_allowed_origins="${API_CORS_ALLOWED_ORIGINS}" >"${APISERVER_LOG}" 2>&1 &
@@ -221,7 +221,7 @@ function start_apiserver {
 
     # Wait for kube-apiserver to come up before launching the rest of the components.
     echo "Waiting for apiserver to come up"
-    kube::util::wait_for_url "http://${API_HOST}:${API_PORT}/api/v1beta3/pods" "apiserver: " 1 10 || exit 1
+    kube::util::wait_for_url "http://${API_HOST}:${API_PORT}/api/v1/pods" "apiserver: " 1 10 || exit 1
 }
 
 function start_controller_manager {
@@ -284,16 +284,13 @@ function start_kubeproxy {
 function print_success {
 cat <<EOF
 Local Kubernetes cluster is running. Press Ctrl-C to shut it down.
-
 Logs:
   ${APISERVER_LOG}
   ${CTLRMGR_LOG}
   ${PROXY_LOG}
   ${SCHEDULER_LOG}
   ${KUBELET_LOG}
-
 To start using your cluster, open up another terminal/tab and run:
-
   cluster/kubectl.sh config set-cluster local --server=http://${API_HOST}:${API_PORT} --insecure-skip-tls-verify=true
   cluster/kubectl.sh config set-context local --cluster=local
   cluster/kubectl.sh config use-context local

--- a/pkg/api/conversion_test.go
+++ b/pkg/api/conversion_test.go
@@ -107,3 +107,31 @@ func BenchmarkReplicationControllerConversion(b *testing.B) {
 		b.Fatalf("Incorrect conversion: expected %v, got %v", replicationController, *result)
 	}
 }
+
+func BenchmarkDaemonControllerConversion(b *testing.B) {
+	data, err := ioutil.ReadFile("daemon_controller_example.json")
+	if err != nil {
+		b.Fatalf("Unexpected error while reading file: %v", err)
+	}
+	var daemonController api.DaemonController
+	if err := api.Scheme.DecodeInto(data, &daemonController); err != nil {
+		b.Fatalf("Unexpected error decoding daemon controller: %v", err)
+	}
+
+	scheme := api.Scheme.Raw()
+	var result *api.DaemonController
+	for i := 0; i < b.N; i++ {
+		versionedObj, err := scheme.ConvertToVersion(&daemonController, testapi.Version())
+		if err != nil {
+			b.Fatalf("Conversion error: %v", err)
+		}
+		obj, err := scheme.ConvertToVersion(versionedObj, scheme.InternalVersion)
+		if err != nil {
+			b.Fatalf("Conversion error: %v", err)
+		}
+		result = obj.(*api.DaemonController)
+	}
+	if !api.Semantic.DeepDerivative(daemonController, *result) {
+		b.Fatalf("Incorrect conversion: expected %v, got %v", daemonController, *result)
+	}
+}

--- a/pkg/api/daemon_controller_example.json
+++ b/pkg/api/daemon_controller_example.json
@@ -1,0 +1,75 @@
+{
+    "kind": "DaemonController",
+    "apiVersion": "v1beta3",
+    "metadata": {
+        "name": "elasticsearch-logging-controller",
+        "namespace": "default",
+        "selfLink": "/api/v1beta3/namespaces/default/daemoncontrollers/elasticsearch-logging-controller",
+        "uid": "aa76f162-e8e5-11e4-8fde-42010af09327",
+        "resourceVersion": "98",
+        "creationTimestamp": "2015-04-22T11:49:43Z",
+        "labels": {
+            "kubernetes.io/cluster-service": "true",
+            "name": "elasticsearch-logging"
+        }
+    },
+    "spec": {
+        "template": {
+            "metadata": {
+                "creationTimestamp": null,
+                "labels": {
+                    "kubernetes.io/cluster-service": "true",
+                    "name": "elasticsearch-logging"
+                }
+            },
+            "spec": {
+                "volumes": [
+                    {
+                        "name": "es-persistent-storage",
+                        "hostPath": null,
+                        "emptyDir": {
+                            "medium": ""
+                        },
+                        "gcePersistentDisk": null,
+                        "awsElasticBlockStore": null,
+                        "gitRepo": null,
+                        "secret": null,
+                        "nfs": null,
+                        "iscsi": null,
+                        "glusterfs": null
+                    }
+                ],
+                "containers": [
+                    {
+                        "name": "elasticsearch-logging",
+                        "image": "gcr.io/google_containers/elasticsearch:1.0",
+                        "ports": [
+                            {
+                                "name": "es-port",
+                                "containerPort": 9200,
+                                "protocol": "TCP"
+                            },
+                            {
+                                "name": "es-transport-port",
+                                "containerPort": 9300,
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "resources": {},
+                        "volumeMounts": [
+                            {
+                                "name": "es-persistent-storage",
+                                "mountPath": "/data"
+                            }
+                        ],
+                        "terminationMessagePath": "/dev/termination-log",
+                        "imagePullPolicy": "IfNotPresent",
+                        "capabilities": {}
+                    }
+                ],
+                "restartPolicy": "Always",
+                "dnsPolicy": "ClusterFirst"
+            }
+        }
+    }
+}

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -359,6 +359,60 @@ func deepCopy_api_ContainerStatus(in ContainerStatus, out *ContainerStatus, c *c
 	return nil
 }
 
+func deepCopy_api_DaemonController(in DaemonController, out *DaemonController, c *conversion.Cloner) error {
+	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+		return err
+	}
+	if err := deepCopy_api_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
+		return err
+	}
+	if err := deepCopy_api_DaemonControllerSpec(in.Spec, &out.Spec, c); err != nil {
+		return err
+	}
+	if err := deepCopy_api_DaemonControllerStatus(in.Status, &out.Status, c); err != nil {
+		return err
+	}
+	return nil
+}
+
+func deepCopy_api_DaemonControllerList(in DaemonControllerList, out *DaemonControllerList, c *conversion.Cloner) error {
+	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+		return err
+	}
+	if err := deepCopy_api_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]DaemonController, len(in.Items))
+		for i := range in.Items {
+			if err := deepCopy_api_DaemonController(in.Items[i], &out.Items[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func deepCopy_api_DaemonControllerSpec(in DaemonControllerSpec, out *DaemonControllerSpec, c *conversion.Cloner) error {
+	if in.Template != nil {
+		out.Template = new(PodTemplateSpec)
+		if err := deepCopy_api_PodTemplateSpec(*in.Template, out.Template, c); err != nil {
+			return err
+		}
+	} else {
+		out.Template = nil
+	}
+	return nil
+}
+
+func deepCopy_api_DaemonControllerStatus(in DaemonControllerStatus, out *DaemonControllerStatus, c *conversion.Cloner) error {
+	out.NodesRunningDaemon = in.NodesRunningDaemon
+	out.NodesShouldRunDaemon = in.NodesShouldRunDaemon
+	return nil
+}
+
 func deepCopy_api_DeleteOptions(in DeleteOptions, out *DeleteOptions, c *conversion.Cloner) error {
 	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
@@ -2157,6 +2211,10 @@ func init() {
 		deepCopy_api_ContainerStateTerminated,
 		deepCopy_api_ContainerStateWaiting,
 		deepCopy_api_ContainerStatus,
+		deepCopy_api_DaemonController,
+		deepCopy_api_DaemonControllerList,
+		deepCopy_api_DaemonControllerSpec,
+		deepCopy_api_DaemonControllerStatus,
 		deepCopy_api_DeleteOptions,
 		deepCopy_api_EmptyDirVolumeSource,
 		deepCopy_api_EndpointAddress,

--- a/pkg/api/deep_copy_test.go
+++ b/pkg/api/deep_copy_test.go
@@ -91,3 +91,26 @@ func BenchmarkReplicationControllerCopy(b *testing.B) {
 		b.Fatalf("Incorrect copy: expected %v, got %v", replicationController, *result)
 	}
 }
+
+func BenchmarkDaemonControllerCopy(b *testing.B) {
+	data, err := ioutil.ReadFile("daemon_controller_example.json")
+	if err != nil {
+		b.Fatalf("Unexpected error while reading file: %v", err)
+	}
+	var daemonController api.DaemonController
+	if err := api.Scheme.DecodeInto(data, &daemonController); err != nil {
+		b.Fatalf("Unexpected error decoding node: %v", err)
+	}
+
+	var result *api.DaemonController
+	for i := 0; i < b.N; i++ {
+		obj, err := api.Scheme.DeepCopy(&daemonController)
+		if err != nil {
+			b.Fatalf("Unexpected error copying daemon controller: %v", err)
+		}
+		result = obj.(*api.DaemonController)
+	}
+	if !api.Semantic.DeepEqual(daemonController, *result) {
+		b.Fatalf("Incorrect copy: expected %v, got %v", daemonController, *result)
+	}
+}

--- a/pkg/api/helpers.go
+++ b/pkg/api/helpers.go
@@ -83,6 +83,7 @@ var standardResources = util.NewStringSet(
 	string(ResourceQuotas),
 	string(ResourceServices),
 	string(ResourceReplicationControllers),
+	string(ResourceDaemonControllers),
 	string(ResourceSecrets),
 	string(ResourcePersistentVolumeClaims),
 	string(ResourceStorage))

--- a/pkg/api/latest/latest_test.go
+++ b/pkg/api/latest/latest_test.go
@@ -74,6 +74,10 @@ func TestRESTMapper(t *testing.T) {
 		t.Errorf("unexpected version mapping: %s %s %v", v, k, err)
 	}
 
+	if v, k, err := RESTMapper.VersionAndKindForResource("daemoncontrollers"); err != nil || v != "v1" || k != "DaemonController" {
+		t.Errorf("unexpected version mapping: %s %s %v", v, k, err)
+	}
+
 	if m, err := RESTMapper.RESTMapping("PodTemplate", ""); err != nil || m.APIVersion != "v1" || m.Resource != "podtemplates" {
 		t.Errorf("unexpected version mapping: %#v %v", m, err)
 	}

--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -32,6 +32,8 @@ func init() {
 		&PodTemplateList{},
 		&ReplicationControllerList{},
 		&ReplicationController{},
+		&DaemonControllerList{},
+		&DaemonController{},
 		&ServiceList{},
 		&Service{},
 		&NodeList{},
@@ -81,6 +83,8 @@ func (*PodTemplate) IsAnAPIObject()               {}
 func (*PodTemplateList) IsAnAPIObject()           {}
 func (*ReplicationController) IsAnAPIObject()     {}
 func (*ReplicationControllerList) IsAnAPIObject() {}
+func (*DaemonController) IsAnAPIObject()          {}
+func (*DaemonControllerList) IsAnAPIObject()      {}
 func (*Service) IsAnAPIObject()                   {}
 func (*ServiceList) IsAnAPIObject()               {}
 func (*Endpoints) IsAnAPIObject()                 {}

--- a/pkg/api/testing/fuzzer.go
+++ b/pkg/api/testing/fuzzer.go
@@ -113,6 +113,13 @@ func FuzzerFor(t *testing.T, version string, src rand.Source) *fuzz.Fuzzer {
 			// only replicas round trips
 			j.Replicas = int(c.RandUint64())
 		},
+		func(j *api.DaemonControllerSpec, c fuzz.Continue) {
+			c.FuzzNoCustom(j) // fuzz self without calling this function again
+		},
+		func(j *api.DaemonControllerStatus, c fuzz.Continue) {
+			j.NodesRunningDaemon = int(c.RandUint64())
+			j.NodesShouldRunDaemon = int(c.RandUint64())
+		},
 		func(j *api.List, c fuzz.Continue) {
 			c.FuzzNoCustom(j) // fuzz self without calling this function again
 			// TODO: uncomment when round trip starts from a versioned object

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1021,6 +1021,46 @@ type ReplicationControllerList struct {
 	Items []ReplicationController `json:"items"`
 }
 
+// DaemonControllerSpec is the specification of a daemon controller.
+type DaemonControllerSpec struct {
+	// Template is the object that describes the pod that will be created.
+	// The Daemon Controller will create this pod on every node that matches
+	// the template's node selector (or on every node if no node selector is
+	// specified).
+	Template *PodTemplateSpec `json:"template,omitempty"`
+}
+
+// DaemonControllerStatus represents the current status of a daemon
+// controller.
+type DaemonControllerStatus struct {
+	// NodesRunningDaemon is the number of nodes running the Daemon.
+	NodesRunningDaemon int `json:"nodesRunningDaemon"`
+
+	// NodesShouldRunDaemon is the number of nodes that should be running the Daemon.
+	NodesShouldRunDaemon int `json:"nodesShouldRunDaemon"`
+}
+
+// DaemonController represents the configuration of a daemon controller.
+type DaemonController struct {
+	TypeMeta   `json:",inline"`
+	ObjectMeta `json:"metadata,omitempty"`
+
+	// Spec defines the desired behavior of this daemon controller.
+	Spec DaemonControllerSpec `json:"spec,omitempty"`
+
+	// Status is the current status of this daemon controller. This data may be
+	// out of date by some window of time.
+	Status DaemonControllerStatus `json:"status,omitempty"`
+}
+
+// DaemonControllerList is a collection of daemon controllers.
+type DaemonControllerList struct {
+	TypeMeta `json:",inline"`
+	ListMeta `json:"metadata,omitempty"`
+
+	Items []DaemonController `json:"items"`
+}
+
 const (
 	// ClusterIPNone - do not assign a cluster IP
 	// no proxying required and no environment variables should be created for pods
@@ -1906,6 +1946,8 @@ const (
 	ResourceServices ResourceName = "services"
 	// ReplicationControllers, number
 	ResourceReplicationControllers ResourceName = "replicationcontrollers"
+	// DaemonControllers, number
+	ResourceDaemonControllers ResourceName = "daemoncontrollers"
 	// ResourceQuotas, number
 	ResourceQuotas ResourceName = "resourcequotas"
 	// ResourceSecrets, number

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -323,6 +323,72 @@ func convert_api_ContainerStatus_To_v1_ContainerStatus(in *api.ContainerStatus, 
 	return nil
 }
 
+func convert_api_DaemonController_To_v1_DaemonController(in *api.DaemonController, out *DaemonController, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*api.DaemonController))(in)
+	}
+	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+	if err := convert_api_DaemonControllerSpec_To_v1_DaemonControllerSpec(&in.Spec, &out.Spec, s); err != nil {
+		return err
+	}
+	if err := convert_api_DaemonControllerStatus_To_v1_DaemonControllerStatus(&in.Status, &out.Status, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_api_DaemonControllerList_To_v1_DaemonControllerList(in *api.DaemonControllerList, out *DaemonControllerList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*api.DaemonControllerList))(in)
+	}
+	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_api_ListMeta_To_v1_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]DaemonController, len(in.Items))
+		for i := range in.Items {
+			if err := convert_api_DaemonController_To_v1_DaemonController(&in.Items[i], &out.Items[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func convert_api_DaemonControllerSpec_To_v1_DaemonControllerSpec(in *api.DaemonControllerSpec, out *DaemonControllerSpec, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*api.DaemonControllerSpec))(in)
+	}
+	if in.Template != nil {
+		out.Template = new(PodTemplateSpec)
+		if err := convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(in.Template, out.Template, s); err != nil {
+			return err
+		}
+	} else {
+		out.Template = nil
+	}
+	return nil
+}
+
+func convert_api_DaemonControllerStatus_To_v1_DaemonControllerStatus(in *api.DaemonControllerStatus, out *DaemonControllerStatus, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*api.DaemonControllerStatus))(in)
+	}
+	out.NodesRunningDaemon = in.NodesRunningDaemon
+	out.NodesShouldRunDaemon = in.NodesShouldRunDaemon
+	return nil
+}
+
 func convert_api_DeleteOptions_To_v1_DeleteOptions(in *api.DeleteOptions, out *DeleteOptions, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.DeleteOptions))(in)
@@ -2631,6 +2697,72 @@ func convert_v1_ContainerStatus_To_api_ContainerStatus(in *ContainerStatus, out 
 	return nil
 }
 
+func convert_v1_DaemonController_To_api_DaemonController(in *DaemonController, out *api.DaemonController, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*DaemonController))(in)
+	}
+	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+	if err := convert_v1_DaemonControllerSpec_To_api_DaemonControllerSpec(&in.Spec, &out.Spec, s); err != nil {
+		return err
+	}
+	if err := convert_v1_DaemonControllerStatus_To_api_DaemonControllerStatus(&in.Status, &out.Status, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_v1_DaemonControllerList_To_api_DaemonControllerList(in *DaemonControllerList, out *api.DaemonControllerList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*DaemonControllerList))(in)
+	}
+	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_v1_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]api.DaemonController, len(in.Items))
+		for i := range in.Items {
+			if err := convert_v1_DaemonController_To_api_DaemonController(&in.Items[i], &out.Items[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func convert_v1_DaemonControllerSpec_To_api_DaemonControllerSpec(in *DaemonControllerSpec, out *api.DaemonControllerSpec, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*DaemonControllerSpec))(in)
+	}
+	if in.Template != nil {
+		out.Template = new(api.PodTemplateSpec)
+		if err := convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(in.Template, out.Template, s); err != nil {
+			return err
+		}
+	} else {
+		out.Template = nil
+	}
+	return nil
+}
+
+func convert_v1_DaemonControllerStatus_To_api_DaemonControllerStatus(in *DaemonControllerStatus, out *api.DaemonControllerStatus, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*DaemonControllerStatus))(in)
+	}
+	out.NodesRunningDaemon = in.NodesRunningDaemon
+	out.NodesShouldRunDaemon = in.NodesShouldRunDaemon
+	return nil
+}
+
 func convert_v1_DeleteOptions_To_api_DeleteOptions(in *DeleteOptions, out *api.DeleteOptions, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*DeleteOptions))(in)
@@ -4656,6 +4788,10 @@ func init() {
 		convert_api_ContainerState_To_v1_ContainerState,
 		convert_api_ContainerStatus_To_v1_ContainerStatus,
 		convert_api_Container_To_v1_Container,
+		convert_api_DaemonControllerList_To_v1_DaemonControllerList,
+		convert_api_DaemonControllerSpec_To_v1_DaemonControllerSpec,
+		convert_api_DaemonControllerStatus_To_v1_DaemonControllerStatus,
+		convert_api_DaemonController_To_v1_DaemonController,
 		convert_api_DeleteOptions_To_v1_DeleteOptions,
 		convert_api_EmptyDirVolumeSource_To_v1_EmptyDirVolumeSource,
 		convert_api_EndpointAddress_To_v1_EndpointAddress,
@@ -4769,6 +4905,10 @@ func init() {
 		convert_v1_ContainerState_To_api_ContainerState,
 		convert_v1_ContainerStatus_To_api_ContainerStatus,
 		convert_v1_Container_To_api_Container,
+		convert_v1_DaemonControllerList_To_api_DaemonControllerList,
+		convert_v1_DaemonControllerSpec_To_api_DaemonControllerSpec,
+		convert_v1_DaemonControllerStatus_To_api_DaemonControllerStatus,
+		convert_v1_DaemonController_To_api_DaemonController,
 		convert_v1_DeleteOptions_To_api_DeleteOptions,
 		convert_v1_EmptyDirVolumeSource_To_api_EmptyDirVolumeSource,
 		convert_v1_EndpointAddress_To_api_EndpointAddress,

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -300,6 +300,60 @@ func deepCopy_v1_ContainerStatus(in ContainerStatus, out *ContainerStatus, c *co
 	return nil
 }
 
+func deepCopy_v1_DaemonController(in DaemonController, out *DaemonController, c *conversion.Cloner) error {
+	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+		return err
+	}
+	if err := deepCopy_v1_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
+		return err
+	}
+	if err := deepCopy_v1_DaemonControllerSpec(in.Spec, &out.Spec, c); err != nil {
+		return err
+	}
+	if err := deepCopy_v1_DaemonControllerStatus(in.Status, &out.Status, c); err != nil {
+		return err
+	}
+	return nil
+}
+
+func deepCopy_v1_DaemonControllerList(in DaemonControllerList, out *DaemonControllerList, c *conversion.Cloner) error {
+	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+		return err
+	}
+	if err := deepCopy_v1_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]DaemonController, len(in.Items))
+		for i := range in.Items {
+			if err := deepCopy_v1_DaemonController(in.Items[i], &out.Items[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func deepCopy_v1_DaemonControllerSpec(in DaemonControllerSpec, out *DaemonControllerSpec, c *conversion.Cloner) error {
+	if in.Template != nil {
+		out.Template = new(PodTemplateSpec)
+		if err := deepCopy_v1_PodTemplateSpec(*in.Template, out.Template, c); err != nil {
+			return err
+		}
+	} else {
+		out.Template = nil
+	}
+	return nil
+}
+
+func deepCopy_v1_DaemonControllerStatus(in DaemonControllerStatus, out *DaemonControllerStatus, c *conversion.Cloner) error {
+	out.NodesRunningDaemon = in.NodesRunningDaemon
+	out.NodesShouldRunDaemon = in.NodesShouldRunDaemon
+	return nil
+}
+
 func deepCopy_v1_DeleteOptions(in DeleteOptions, out *DeleteOptions, c *conversion.Cloner) error {
 	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
@@ -2090,6 +2144,10 @@ func init() {
 		deepCopy_v1_ContainerStateTerminated,
 		deepCopy_v1_ContainerStateWaiting,
 		deepCopy_v1_ContainerStatus,
+		deepCopy_v1_DaemonController,
+		deepCopy_v1_DaemonControllerList,
+		deepCopy_v1_DaemonControllerSpec,
+		deepCopy_v1_DaemonControllerStatus,
 		deepCopy_v1_DeleteOptions,
 		deepCopy_v1_EmptyDirVolumeSource,
 		deepCopy_v1_EndpointAddress,

--- a/pkg/api/v1/defaults.go
+++ b/pkg/api/v1/defaults.go
@@ -44,6 +44,18 @@ func addDefaultingFuncs() {
 				*obj.Spec.Replicas = 1
 			}
 		},
+		func(obj *DaemonController) {
+			var labels map[string]string
+			if obj.Spec.Template != nil {
+				labels = obj.Spec.Template.Labels
+			}
+			// TODO: support templates defined elsewhere when we support them in the API
+			if labels != nil {
+				if len(obj.Labels) == 0 {
+					obj.Labels = labels
+				}
+			}
+		},
 		func(obj *Volume) {
 			if util.AllPtrFieldsNil(&obj.VolumeSource) {
 				obj.VolumeSource = VolumeSource{

--- a/pkg/api/v1/defaults_test.go
+++ b/pkg/api/v1/defaults_test.go
@@ -155,6 +155,64 @@ func TestSetDefaultReplicationController(t *testing.T) {
 	}
 }
 
+func TestSetDefaultDaemonController(t *testing.T) {
+	tests := []struct {
+		dc                 *versioned.DaemonController
+		expectLabelsChange bool
+	}{
+		{
+			dc: &versioned.DaemonController{
+				Spec: versioned.DaemonControllerSpec{
+					Template: &versioned.PodTemplateSpec{
+						ObjectMeta: versioned.ObjectMeta{
+							Labels: map[string]string{
+								"foo": "bar",
+							},
+						},
+					},
+				},
+			},
+			expectLabelsChange: true,
+		},
+		{
+			dc: &versioned.DaemonController{
+				ObjectMeta: versioned.ObjectMeta{
+					Labels: map[string]string{
+						"bar": "foo",
+					},
+				},
+				Spec: versioned.DaemonControllerSpec{
+					Template: &versioned.PodTemplateSpec{
+						ObjectMeta: versioned.ObjectMeta{
+							Labels: map[string]string{
+								"foo": "bar",
+							},
+						},
+					},
+				},
+			},
+			expectLabelsChange: false,
+		},
+	}
+
+	for _, test := range tests {
+		dc := test.dc
+		obj2 := roundTrip(t, runtime.Object(dc))
+		dc2, ok := obj2.(*versioned.DaemonController)
+		if !ok {
+			t.Errorf("unexpected object: %v", dc2)
+			t.FailNow()
+		}
+		if test.expectLabelsChange != reflect.DeepEqual(dc2.Labels, dc2.Spec.Template.Labels) {
+			if test.expectLabelsChange {
+				t.Errorf("expected: %v, got: %v", dc2.Spec.Template.Labels, dc2.Labels)
+			} else {
+				t.Errorf("unexpected equality: %v", dc.Labels)
+			}
+		}
+	}
+}
+
 func newInt(val int) *int {
 	p := new(int)
 	*p = val

--- a/pkg/api/v1/register.go
+++ b/pkg/api/v1/register.go
@@ -47,6 +47,8 @@ func addKnownTypes() {
 		&PodTemplateList{},
 		&ReplicationController{},
 		&ReplicationControllerList{},
+		&DaemonControllerList{},
+		&DaemonController{},
 		&Service{},
 		&ServiceList{},
 		&Endpoints{},
@@ -94,6 +96,8 @@ func (*PodTemplate) IsAnAPIObject()               {}
 func (*PodTemplateList) IsAnAPIObject()           {}
 func (*ReplicationController) IsAnAPIObject()     {}
 func (*ReplicationControllerList) IsAnAPIObject() {}
+func (*DaemonController) IsAnAPIObject()          {}
+func (*DaemonControllerList) IsAnAPIObject()      {}
 func (*Service) IsAnAPIObject()                   {}
 func (*ServiceList) IsAnAPIObject()               {}
 func (*Endpoints) IsAnAPIObject()                 {}

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -1025,6 +1025,46 @@ type ReplicationControllerList struct {
 	Items []ReplicationController `json:"items" description:"list of replication controllers"`
 }
 
+// DaemonControllerSpec is the specification of a daemon controller.
+type DaemonControllerSpec struct {
+	// Template is the object that describes the pod that will be created.
+	// The Daemon Controller will create this pod on every node that matches
+	// the template's node selector (or on every node if no node selector is
+	// specified).
+	Template *PodTemplateSpec `json:"template,omitempty"`
+}
+
+// DaemonControllerStatus represents the current status of a daemon
+// controller.
+type DaemonControllerStatus struct {
+	// NodesRunningDaemon is the number of nodes running the Daemon.
+	NodesRunningDaemon int `json:"nodes_running_daemon"`
+
+	// NodesShouldRunDaemon is the number of nodes that should be running the Daemon.
+	NodesShouldRunDaemon int `json:"nodes_should_run_daemon"`
+}
+
+// DaemonController represents the configuration of a daemon controller.
+type DaemonController struct {
+	TypeMeta   `json:",inline"`
+	ObjectMeta `json:"metadata,omitempty"`
+
+	// Spec defines the desired behavior of this daemon controller.
+	Spec DaemonControllerSpec `json:"spec,omitempty"`
+
+	// Status is the current status of this daemon controller. This data may be
+	// out of date by some window of time.
+	Status DaemonControllerStatus `json:"status,omitempty"`
+}
+
+// DaemonControllerList is a collection of daemon controllers.
+type DaemonControllerList struct {
+	TypeMeta `json:",inline"`
+	ListMeta `json:"metadata,omitempty"`
+
+	Items []DaemonController `json:"items"`
+}
+
 // Session Affinity Type string
 type ServiceAffinity string
 
@@ -1801,6 +1841,8 @@ const (
 	ResourceServices ResourceName = "services"
 	// ReplicationControllers, number
 	ResourceReplicationControllers ResourceName = "replicationcontrollers"
+	// DaemonControllers, number
+	ResourceDaemonControllers ResourceName = "daemoncontrollers"
 	// ResourceQuotas, number
 	ResourceQuotas ResourceName = "resourcequotas"
 	// ResourceSecrets, number

--- a/pkg/api/v1beta3/conversion_generated.go
+++ b/pkg/api/v1beta3/conversion_generated.go
@@ -181,6 +181,72 @@ func convert_api_ContainerStatus_To_v1beta3_ContainerStatus(in *api.ContainerSta
 	return nil
 }
 
+func convert_api_DaemonController_To_v1beta3_DaemonController(in *api.DaemonController, out *DaemonController, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*api.DaemonController))(in)
+	}
+	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_api_ObjectMeta_To_v1beta3_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+	if err := convert_api_DaemonControllerSpec_To_v1beta3_DaemonControllerSpec(&in.Spec, &out.Spec, s); err != nil {
+		return err
+	}
+	if err := convert_api_DaemonControllerStatus_To_v1beta3_DaemonControllerStatus(&in.Status, &out.Status, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_api_DaemonControllerList_To_v1beta3_DaemonControllerList(in *api.DaemonControllerList, out *DaemonControllerList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*api.DaemonControllerList))(in)
+	}
+	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_api_ListMeta_To_v1beta3_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]DaemonController, len(in.Items))
+		for i := range in.Items {
+			if err := convert_api_DaemonController_To_v1beta3_DaemonController(&in.Items[i], &out.Items[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func convert_api_DaemonControllerSpec_To_v1beta3_DaemonControllerSpec(in *api.DaemonControllerSpec, out *DaemonControllerSpec, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*api.DaemonControllerSpec))(in)
+	}
+	if in.Template != nil {
+		out.Template = new(PodTemplateSpec)
+		if err := convert_api_PodTemplateSpec_To_v1beta3_PodTemplateSpec(in.Template, out.Template, s); err != nil {
+			return err
+		}
+	} else {
+		out.Template = nil
+	}
+	return nil
+}
+
+func convert_api_DaemonControllerStatus_To_v1beta3_DaemonControllerStatus(in *api.DaemonControllerStatus, out *DaemonControllerStatus, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*api.DaemonControllerStatus))(in)
+	}
+	out.NodesRunningDaemon = in.NodesRunningDaemon
+	out.NodesShouldRunDaemon = in.NodesShouldRunDaemon
+	return nil
+}
+
 func convert_api_DeleteOptions_To_v1beta3_DeleteOptions(in *api.DeleteOptions, out *DeleteOptions, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.DeleteOptions))(in)
@@ -2243,6 +2309,72 @@ func convert_v1beta3_ContainerStatus_To_api_ContainerStatus(in *ContainerStatus,
 	return nil
 }
 
+func convert_v1beta3_DaemonController_To_api_DaemonController(in *DaemonController, out *api.DaemonController, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*DaemonController))(in)
+	}
+	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_v1beta3_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+	if err := convert_v1beta3_DaemonControllerSpec_To_api_DaemonControllerSpec(&in.Spec, &out.Spec, s); err != nil {
+		return err
+	}
+	if err := convert_v1beta3_DaemonControllerStatus_To_api_DaemonControllerStatus(&in.Status, &out.Status, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_v1beta3_DaemonControllerList_To_api_DaemonControllerList(in *DaemonControllerList, out *api.DaemonControllerList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*DaemonControllerList))(in)
+	}
+	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_v1beta3_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]api.DaemonController, len(in.Items))
+		for i := range in.Items {
+			if err := convert_v1beta3_DaemonController_To_api_DaemonController(&in.Items[i], &out.Items[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func convert_v1beta3_DaemonControllerSpec_To_api_DaemonControllerSpec(in *DaemonControllerSpec, out *api.DaemonControllerSpec, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*DaemonControllerSpec))(in)
+	}
+	if in.Template != nil {
+		out.Template = new(api.PodTemplateSpec)
+		if err := convert_v1beta3_PodTemplateSpec_To_api_PodTemplateSpec(in.Template, out.Template, s); err != nil {
+			return err
+		}
+	} else {
+		out.Template = nil
+	}
+	return nil
+}
+
+func convert_v1beta3_DaemonControllerStatus_To_api_DaemonControllerStatus(in *DaemonControllerStatus, out *api.DaemonControllerStatus, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*DaemonControllerStatus))(in)
+	}
+	out.NodesRunningDaemon = in.NodesRunningDaemon
+	out.NodesShouldRunDaemon = in.NodesShouldRunDaemon
+	return nil
+}
+
 func convert_v1beta3_DeleteOptions_To_api_DeleteOptions(in *DeleteOptions, out *api.DeleteOptions, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*DeleteOptions))(in)
@@ -4161,6 +4293,10 @@ func init() {
 		convert_api_ContainerStateRunning_To_v1beta3_ContainerStateRunning,
 		convert_api_ContainerStateWaiting_To_v1beta3_ContainerStateWaiting,
 		convert_api_ContainerStatus_To_v1beta3_ContainerStatus,
+		convert_api_DaemonControllerList_To_v1beta3_DaemonControllerList,
+		convert_api_DaemonControllerSpec_To_v1beta3_DaemonControllerSpec,
+		convert_api_DaemonControllerStatus_To_v1beta3_DaemonControllerStatus,
+		convert_api_DaemonController_To_v1beta3_DaemonController,
 		convert_api_DeleteOptions_To_v1beta3_DeleteOptions,
 		convert_api_EmptyDirVolumeSource_To_v1beta3_EmptyDirVolumeSource,
 		convert_api_EndpointAddress_To_v1beta3_EndpointAddress,
@@ -4268,6 +4404,10 @@ func init() {
 		convert_v1beta3_ContainerStateRunning_To_api_ContainerStateRunning,
 		convert_v1beta3_ContainerStateWaiting_To_api_ContainerStateWaiting,
 		convert_v1beta3_ContainerStatus_To_api_ContainerStatus,
+		convert_v1beta3_DaemonControllerList_To_api_DaemonControllerList,
+		convert_v1beta3_DaemonControllerSpec_To_api_DaemonControllerSpec,
+		convert_v1beta3_DaemonControllerStatus_To_api_DaemonControllerStatus,
+		convert_v1beta3_DaemonController_To_api_DaemonController,
 		convert_v1beta3_DeleteOptions_To_api_DeleteOptions,
 		convert_v1beta3_EmptyDirVolumeSource_To_api_EmptyDirVolumeSource,
 		convert_v1beta3_EndpointAddress_To_api_EndpointAddress,

--- a/pkg/api/v1beta3/deep_copy_generated.go
+++ b/pkg/api/v1beta3/deep_copy_generated.go
@@ -304,6 +304,60 @@ func deepCopy_v1beta3_ContainerStatus(in ContainerStatus, out *ContainerStatus, 
 	return nil
 }
 
+func deepCopy_v1beta3_DaemonController(in DaemonController, out *DaemonController, c *conversion.Cloner) error {
+	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+		return err
+	}
+	if err := deepCopy_v1beta3_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
+		return err
+	}
+	if err := deepCopy_v1beta3_DaemonControllerSpec(in.Spec, &out.Spec, c); err != nil {
+		return err
+	}
+	if err := deepCopy_v1beta3_DaemonControllerStatus(in.Status, &out.Status, c); err != nil {
+		return err
+	}
+	return nil
+}
+
+func deepCopy_v1beta3_DaemonControllerList(in DaemonControllerList, out *DaemonControllerList, c *conversion.Cloner) error {
+	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+		return err
+	}
+	if err := deepCopy_v1beta3_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]DaemonController, len(in.Items))
+		for i := range in.Items {
+			if err := deepCopy_v1beta3_DaemonController(in.Items[i], &out.Items[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func deepCopy_v1beta3_DaemonControllerSpec(in DaemonControllerSpec, out *DaemonControllerSpec, c *conversion.Cloner) error {
+	if in.Template != nil {
+		out.Template = new(PodTemplateSpec)
+		if err := deepCopy_v1beta3_PodTemplateSpec(*in.Template, out.Template, c); err != nil {
+			return err
+		}
+	} else {
+		out.Template = nil
+	}
+	return nil
+}
+
+func deepCopy_v1beta3_DaemonControllerStatus(in DaemonControllerStatus, out *DaemonControllerStatus, c *conversion.Cloner) error {
+	out.NodesRunningDaemon = in.NodesRunningDaemon
+	out.NodesShouldRunDaemon = in.NodesShouldRunDaemon
+	return nil
+}
+
 func deepCopy_v1beta3_DeleteOptions(in DeleteOptions, out *DeleteOptions, c *conversion.Cloner) error {
 	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
@@ -2090,6 +2144,10 @@ func init() {
 		deepCopy_v1beta3_ContainerStateTerminated,
 		deepCopy_v1beta3_ContainerStateWaiting,
 		deepCopy_v1beta3_ContainerStatus,
+		deepCopy_v1beta3_DaemonController,
+		deepCopy_v1beta3_DaemonControllerList,
+		deepCopy_v1beta3_DaemonControllerSpec,
+		deepCopy_v1beta3_DaemonControllerStatus,
 		deepCopy_v1beta3_DeleteOptions,
 		deepCopy_v1beta3_EmptyDirVolumeSource,
 		deepCopy_v1beta3_EndpointAddress,

--- a/pkg/api/v1beta3/defaults.go
+++ b/pkg/api/v1beta3/defaults.go
@@ -41,6 +41,18 @@ func addDefaultingFuncs() {
 				}
 			}
 		},
+		func(obj *DaemonController) {
+			var labels map[string]string
+			if obj.Spec.Template != nil {
+				labels = obj.Spec.Template.Labels
+			}
+			// TODO: support templates defined elsewhere when we support them in the API
+			if labels != nil {
+				if len(obj.Labels) == 0 {
+					obj.Labels = labels
+				}
+			}
+		},
 		func(obj *Volume) {
 			if util.AllPtrFieldsNil(&obj.VolumeSource) {
 				obj.VolumeSource = VolumeSource{

--- a/pkg/api/v1beta3/defaults_test.go
+++ b/pkg/api/v1beta3/defaults_test.go
@@ -155,6 +155,64 @@ func TestSetDefaultReplicationController(t *testing.T) {
 	}
 }
 
+func TestSetDefaultDaemonController(t *testing.T) {
+	tests := []struct {
+		dc                 *versioned.DaemonController
+		expectLabelsChange bool
+	}{
+		{
+			dc: &versioned.DaemonController{
+				Spec: versioned.DaemonControllerSpec{
+					Template: &versioned.PodTemplateSpec{
+						ObjectMeta: versioned.ObjectMeta{
+							Labels: map[string]string{
+								"foo": "bar",
+							},
+						},
+					},
+				},
+			},
+			expectLabelsChange: true,
+		},
+		{
+			dc: &versioned.DaemonController{
+				ObjectMeta: versioned.ObjectMeta{
+					Labels: map[string]string{
+						"bar": "foo",
+					},
+				},
+				Spec: versioned.DaemonControllerSpec{
+					Template: &versioned.PodTemplateSpec{
+						ObjectMeta: versioned.ObjectMeta{
+							Labels: map[string]string{
+								"foo": "bar",
+							},
+						},
+					},
+				},
+			},
+			expectLabelsChange: false,
+		},
+	}
+
+	for _, test := range tests {
+		dc := test.dc
+		obj2 := roundTrip(t, runtime.Object(dc))
+		dc2, ok := obj2.(*versioned.DaemonController)
+		if !ok {
+			t.Errorf("unexpected object: %v", dc2)
+			t.FailNow()
+		}
+		if test.expectLabelsChange != reflect.DeepEqual(dc2.Labels, dc2.Spec.Template.Labels) {
+			if test.expectLabelsChange {
+				t.Errorf("expected: %v, got: %v", dc2.Spec.Template.Labels, dc2.Labels)
+			} else {
+				t.Errorf("unexpected equality: %v", dc.Labels)
+			}
+		}
+	}
+}
+
 func TestSetDefaultService(t *testing.T) {
 	svc := &versioned.Service{}
 	obj2 := roundTrip(t, runtime.Object(svc))

--- a/pkg/api/v1beta3/register.go
+++ b/pkg/api/v1beta3/register.go
@@ -47,6 +47,8 @@ func addKnownTypes() {
 		&PodTemplateList{},
 		&ReplicationController{},
 		&ReplicationControllerList{},
+		&DaemonControllerList{},
+		&DaemonController{},
 		&Service{},
 		&ServiceList{},
 		&Endpoints{},
@@ -94,6 +96,8 @@ func (*PodTemplate) IsAnAPIObject()               {}
 func (*PodTemplateList) IsAnAPIObject()           {}
 func (*ReplicationController) IsAnAPIObject()     {}
 func (*ReplicationControllerList) IsAnAPIObject() {}
+func (*DaemonController) IsAnAPIObject()          {}
+func (*DaemonControllerList) IsAnAPIObject()      {}
 func (*Service) IsAnAPIObject()                   {}
 func (*ServiceList) IsAnAPIObject()               {}
 func (*Endpoints) IsAnAPIObject()                 {}

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -1029,6 +1029,46 @@ type ReplicationControllerList struct {
 	Items []ReplicationController `json:"items" description:"list of replication controllers"`
 }
 
+// DaemonControllerSpec is the specification of a daemon controller.
+type DaemonControllerSpec struct {
+	// Template is the object that describes the pod that will be created.
+	// The Daemon Controller will create this pod on every node that matches
+	// the template's node selector (or on every node if no node selector is
+	// specified).
+	Template *PodTemplateSpec `json:"template,omitempty"`
+}
+
+// DaemonControllerStatus represents the current status of a daemon
+// controller.
+type DaemonControllerStatus struct {
+	// NodesRunningDaemon is the number of nodes running the Daemon.
+	NodesRunningDaemon int `json:"nodes_running_daemon"`
+
+	// NodesShouldRunDaemon is the number of nodes that should be running the Daemon.
+	NodesShouldRunDaemon int `json:"nodes_should_run_daemon"`
+}
+
+// DaemonController represents the configuration of a daemon controller.
+type DaemonController struct {
+	TypeMeta   `json:",inline"`
+	ObjectMeta `json:"metadata,omitempty"`
+
+	// Spec defines the desired behavior of this daemon controller.
+	Spec DaemonControllerSpec `json:"spec,omitempty"`
+
+	// Status is the current status of this daemon controller. This data may be
+	// out of date by some window of time.
+	Status DaemonControllerStatus `json:"status,omitempty"`
+}
+
+// DaemonControllerList is a collection of daemon controllers.
+type DaemonControllerList struct {
+	TypeMeta `json:",inline"`
+	ListMeta `json:"metadata,omitempty"`
+
+	Items []DaemonController `json:"items"`
+}
+
 // Session Affinity Type string
 type ServiceAffinity string
 
@@ -1808,6 +1848,8 @@ const (
 	ResourceServices ResourceName = "services"
 	// ReplicationControllers, number
 	ResourceReplicationControllers ResourceName = "replicationcontrollers"
+	// DaemonControllers, number
+	ResourceDaemonControllers ResourceName = "daemoncontrollers"
 	// ResourceQuotas, number
 	ResourceQuotas ResourceName = "resourcequotas"
 	// ResourceSecrets, number

--- a/pkg/api/validation/schema_test.go
+++ b/pkg/api/validation/schema_test.go
@@ -63,6 +63,7 @@ func TestValidateOk(t *testing.T) {
 		{obj: &api.Pod{}},
 		{obj: &api.Service{}},
 		{obj: &api.ReplicationController{}},
+		{obj: &api.DaemonController{}},
 	}
 
 	seed := rand.Int63()
@@ -71,6 +72,7 @@ func TestValidateOk(t *testing.T) {
 		for _, test := range tests {
 			testObj := test.obj
 			apiObjectFuzzer.Fuzz(testObj)
+
 			data, err := testapi.Codec().Encode(testObj)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -47,6 +47,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/master/ports"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/componentstatus"
 	controlleretcd "github.com/GoogleCloudPlatform/kubernetes/pkg/registry/controller/etcd"
+	daemonetcd "github.com/GoogleCloudPlatform/kubernetes/pkg/registry/daemoncontroller/etcd"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/endpoint"
 	endpointsetcd "github.com/GoogleCloudPlatform/kubernetes/pkg/registry/endpoint/etcd"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/etcd"
@@ -454,6 +455,7 @@ func (m *Master) init(c *Config) {
 	m.serviceNodePortAllocator = serviceNodePortRegistry
 
 	controllerStorage := controlleretcd.NewREST(c.EtcdHelper)
+	daemonControllerStorage := daemonetcd.NewREST(c.EtcdHelper)
 
 	// TODO: Factor out the core API registration
 	m.storage = map[string]rest.Storage{
@@ -469,6 +471,7 @@ func (m *Master) init(c *Config) {
 		"podTemplates": podTemplateStorage,
 
 		"replicationControllers": controllerStorage,
+		"daemonControllers":      daemonControllerStorage,
 		"services":               service.NewStorage(m.serviceRegistry, m.nodeRegistry, m.endpointRegistry, serviceClusterIPAllocator, serviceNodePortAllocator, c.ClusterName),
 		"endpoints":              endpointsStorage,
 		"minions":                nodeStorage,

--- a/pkg/registry/daemoncontroller/doc.go
+++ b/pkg/registry/daemoncontroller/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package daemoncontroller provides Registry interface and it's RESTStorage
+// implementation for storing DaemonController api objects.
+package daemoncontroller

--- a/pkg/registry/daemoncontroller/etcd/etcd.go
+++ b/pkg/registry/daemoncontroller/etcd/etcd.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcd
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/daemoncontroller"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic"
+	etcdgeneric "github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic/etcd"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+)
+
+// rest implements a RESTStorage for daemon controllers against etcd
+type REST struct {
+	*etcdgeneric.Etcd
+}
+
+// controllerPrefix is the location for controllers in etcd, only exposed
+// for testing
+var controllerPrefix = "/daemoncontrollers"
+
+// NewREST returns a RESTStorage object that will work against daemon controllers.
+func NewREST(h tools.EtcdHelper) *REST {
+	store := &etcdgeneric.Etcd{
+		NewFunc: func() runtime.Object { return &api.DaemonController{} },
+
+		// NewListFunc returns an object capable of storing results of an etcd list.
+		NewListFunc: func() runtime.Object { return &api.DaemonControllerList{} },
+		// Produces a path that etcd understands, to the root of the resource
+		// by combining the namespace in the context with the given prefix
+		KeyRootFunc: func(ctx api.Context) string {
+			return etcdgeneric.NamespaceKeyRootFunc(ctx, controllerPrefix)
+		},
+		// Produces a path that etcd understands, to the resource by combining
+		// the namespace in the context with the given prefix
+		KeyFunc: func(ctx api.Context, name string) (string, error) {
+			return etcdgeneric.NamespaceKeyFunc(ctx, controllerPrefix, name)
+		},
+		// Retrieve the name field of a daemon controller
+		ObjectNameFunc: func(obj runtime.Object) (string, error) {
+			return obj.(*api.DaemonController).Name, nil
+		},
+		// Used to match objects based on labels/fields for list and watch
+		PredicateFunc: func(label labels.Selector, field fields.Selector) generic.Matcher {
+			return daemoncontroller.MatchController(label, field)
+		},
+		EndpointName: "daemonControllers",
+
+		// Used to validate daemon controller creation
+		CreateStrategy: daemoncontroller.Strategy,
+
+		// Used to validate daemon controller updates
+		UpdateStrategy: daemoncontroller.Strategy,
+
+		Helper: h,
+	}
+
+	return &REST{store}
+}

--- a/pkg/registry/daemoncontroller/etcd/etcd_test.go
+++ b/pkg/registry/daemoncontroller/etcd/etcd_test.go
@@ -1,0 +1,729 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcd
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/rest/resttest"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	etcdgeneric "github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic/etcd"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools/etcdtest"
+	"github.com/coreos/go-etcd/etcd"
+)
+
+const (
+	PASS = iota
+	FAIL
+)
+
+func newHelper(t *testing.T) (*tools.FakeEtcdClient, tools.EtcdHelper) {
+	fakeEtcdClient := tools.NewFakeEtcdClient(t)
+	fakeEtcdClient.TestIndex = true
+	helper := tools.NewEtcdHelper(fakeEtcdClient, latest.Codec, etcdtest.PathPrefix())
+	return fakeEtcdClient, helper
+}
+
+// newStorage creates a REST storage backed by etcd helpers
+func newStorage(t *testing.T) (*REST, *tools.FakeEtcdClient) {
+	fakeEtcdClient, h := newHelper(t)
+	storage := NewREST(h)
+	return storage, fakeEtcdClient
+}
+
+// createController is a helper function that returns a controller with the updated resource version.
+func createController(storage *REST, dc api.DaemonController, t *testing.T) (api.DaemonController, error) {
+	ctx := api.WithNamespace(api.NewContext(), dc.Namespace)
+	obj, err := storage.Create(ctx, &dc)
+	if err != nil {
+		t.Errorf("Failed to create controller, %v", err)
+	}
+	newDc := obj.(*api.DaemonController)
+	return *newDc, nil
+}
+
+var validPodTemplate = api.PodTemplate{
+	Template: api.PodTemplateSpec{
+		ObjectMeta: api.ObjectMeta{
+			Labels: map[string]string{"a": "b"},
+		},
+		Spec: api.PodSpec{
+			Containers: []api.Container{
+				{
+					Name:            "test",
+					Image:           "test_image",
+					ImagePullPolicy: api.PullIfNotPresent,
+				},
+			},
+			RestartPolicy: api.RestartPolicyAlways,
+			DNSPolicy:     api.DNSClusterFirst,
+		},
+	},
+}
+
+var validControllerSpec = api.DaemonControllerSpec{
+	Template: &validPodTemplate.Template,
+}
+
+var validController = api.DaemonController{
+	ObjectMeta: api.ObjectMeta{Name: "foo", Namespace: "default"},
+	Spec:       validControllerSpec,
+}
+
+// makeControllerKey constructs etcd paths to controller items enforcing namespace rules.
+func makeControllerKey(ctx api.Context, id string) (string, error) {
+	return etcdgeneric.NamespaceKeyFunc(ctx, controllerPrefix, id)
+}
+
+// makeControllerListKey constructs etcd paths to the root of the resource,
+// not a specific controller resource
+func makeControllerListKey(ctx api.Context) string {
+	return etcdgeneric.NamespaceKeyRootFunc(ctx, controllerPrefix)
+}
+
+func TestEtcdCreateController(t *testing.T) {
+	ctx := api.NewDefaultContext()
+	storage, fakeClient := newStorage(t)
+	_, err := storage.Create(ctx, &validController)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	key, _ := makeControllerKey(ctx, validController.Name)
+	key = etcdtest.AddPrefix(key)
+	resp, err := fakeClient.Get(key, false, false)
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	var ctrl api.DaemonController
+	err = latest.Codec.DecodeInto([]byte(resp.Node.Value), &ctrl)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if ctrl.Name != "foo" {
+		t.Errorf("Unexpected controller: %#v %s", ctrl, resp.Node.Value)
+	}
+}
+
+func TestEtcdCreateControllerAlreadyExisting(t *testing.T) {
+	ctx := api.NewDefaultContext()
+	storage, fakeClient := newStorage(t)
+	key, _ := makeControllerKey(ctx, validController.Name)
+	key = etcdtest.AddPrefix(key)
+	fakeClient.Set(key, runtime.EncodeOrDie(latest.Codec, &validController), 0)
+
+	_, err := storage.Create(ctx, &validController)
+	if !errors.IsAlreadyExists(err) {
+		t.Errorf("expected already exists err, got %#v", err)
+	}
+}
+
+func TestEtcdCreateControllerValidates(t *testing.T) {
+	ctx := api.NewDefaultContext()
+	storage, _ := newStorage(t)
+	emptyName := validController
+	emptyName.Name = ""
+	failureCases := []api.DaemonController{emptyName}
+	for _, failureCase := range failureCases {
+		c, err := storage.Create(ctx, &failureCase)
+		if c != nil {
+			t.Errorf("Expected nil channel")
+		}
+		if !errors.IsInvalid(err) {
+			t.Errorf("Expected to get an invalid resource error, got %v", err)
+		}
+	}
+}
+
+func TestCreateControllerWithGeneratedName(t *testing.T) {
+	storage, _ := newStorage(t)
+	controller := &api.DaemonController{
+		ObjectMeta: api.ObjectMeta{
+			Namespace:    api.NamespaceDefault,
+			GenerateName: "dc-",
+		},
+		Spec: api.DaemonControllerSpec{
+			Template: &validPodTemplate.Template,
+		},
+	}
+
+	ctx := api.NewDefaultContext()
+	_, err := storage.Create(ctx, controller)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if controller.Name == "dc-" || !strings.HasPrefix(controller.Name, "dc-") {
+		t.Errorf("unexpected name: %#v", controller)
+	}
+}
+
+func TestCreateControllerWithConflictingNamespace(t *testing.T) {
+	storage, _ := newStorage(t)
+	controller := &api.DaemonController{
+		ObjectMeta: api.ObjectMeta{Name: "test", Namespace: "not-default"},
+	}
+
+	ctx := api.NewDefaultContext()
+	channel, err := storage.Create(ctx, controller)
+	if channel != nil {
+		t.Error("Expected a nil channel, but we got a value")
+	}
+	errSubString := "namespace"
+	if err == nil {
+		t.Errorf("Expected an error, but we didn't get one")
+	} else if !errors.IsBadRequest(err) ||
+		strings.Index(err.Error(), errSubString) == -1 {
+		t.Errorf("Expected a Bad Request error with the sub string '%s', got %v", errSubString, err)
+	}
+}
+
+func TestEtcdGetController(t *testing.T) {
+	ctx := api.NewDefaultContext()
+	storage, fakeClient := newStorage(t)
+	key, _ := makeControllerKey(ctx, validController.Name)
+	key = etcdtest.AddPrefix(key)
+	fakeClient.Set(key, runtime.EncodeOrDie(latest.Codec, &validController), 0)
+	ctrl, err := storage.Get(ctx, validController.Name)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	controller, ok := ctrl.(*api.DaemonController)
+	if !ok {
+		t.Errorf("Expected a controller, got %#v", ctrl)
+	}
+	if controller.Name != validController.Name {
+		t.Errorf("Unexpected controller: %#v", controller)
+	}
+}
+
+func TestEtcdControllerValidatesUpdate(t *testing.T) {
+	ctx := api.NewDefaultContext()
+	storage, _ := newStorage(t)
+
+	updateController, err := createController(storage, validController, t)
+	if err != nil {
+		t.Errorf("Failed to create controller, cannot proceed with test.")
+	}
+
+	updaters := []func(dc api.DaemonController) (runtime.Object, bool, error){
+		func(dc api.DaemonController) (runtime.Object, bool, error) {
+			dc.UID = "newUID"
+			return storage.Update(ctx, &dc)
+		},
+		func(dc api.DaemonController) (runtime.Object, bool, error) {
+			dc.Name = ""
+			return storage.Update(ctx, &dc)
+		},
+		func(dc api.DaemonController) (runtime.Object, bool, error) {
+			dc.Spec.Template.Spec.RestartPolicy = api.RestartPolicyOnFailure
+			return storage.Update(ctx, &dc)
+		},
+	}
+	for _, u := range updaters {
+		c, updated, err := u(updateController)
+		if c != nil || updated {
+			t.Errorf("Expected nil object and not created")
+		}
+		if !errors.IsInvalid(err) && !errors.IsBadRequest(err) {
+			t.Errorf("Expected invalid or bad request error, got %v of type %T", err, err)
+		}
+	}
+}
+
+func TestEtcdControllerValidatesNamespaceOnUpdate(t *testing.T) {
+	storage, _ := newStorage(t)
+	ns := "newnamespace"
+
+	// The update should fail if the namespace on the controller is set to something
+	// other than the namespace on the given context, even if the namespace on the
+	// controller is valid.
+	updateController, err := createController(storage, validController, t)
+
+	newNamespaceController := validController
+	newNamespaceController.Namespace = ns
+	_, err = createController(storage, newNamespaceController, t)
+
+	c, updated, err := storage.Update(api.WithNamespace(api.NewContext(), ns), &updateController)
+	if c != nil || updated {
+		t.Errorf("Expected nil object and not created")
+	}
+	// TODO: Be more paranoid about the type of error and make sure it has the substring
+	// "namespace" in it, once #5684 is fixed. Ideally this would be a NewBadRequest.
+	if err == nil {
+		t.Errorf("Expected an error, but we didn't get one")
+	}
+}
+
+// TestEtcdGetControllerDifferentNamespace ensures same-name controllers in different namespaces do not clash
+func TestEtcdGetControllerDifferentNamespace(t *testing.T) {
+	storage, fakeClient := newStorage(t)
+
+	otherNs := "other"
+	ctx1 := api.NewDefaultContext()
+	ctx2 := api.WithNamespace(api.NewContext(), otherNs)
+
+	key1, _ := makeControllerKey(ctx1, validController.Name)
+	key2, _ := makeControllerKey(ctx2, validController.Name)
+
+	key1 = etcdtest.AddPrefix(key1)
+	key2 = etcdtest.AddPrefix(key2)
+
+	fakeClient.Set(key1, runtime.EncodeOrDie(latest.Codec, &validController), 0)
+	otherNsController := validController
+	otherNsController.Namespace = otherNs
+	fakeClient.Set(key2, runtime.EncodeOrDie(latest.Codec, &otherNsController), 0)
+
+	obj, err := storage.Get(ctx1, validController.Name)
+	ctrl1, _ := obj.(*api.DaemonController)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if ctrl1.Name != "foo" {
+		t.Errorf("Unexpected controller: %#v", ctrl1)
+	}
+	if ctrl1.Namespace != "default" {
+		t.Errorf("Unexpected controller: %#v", ctrl1)
+	}
+
+	obj, err = storage.Get(ctx2, validController.Name)
+	ctrl2, _ := obj.(*api.DaemonController)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if ctrl2.Name != "foo" {
+		t.Errorf("Unexpected controller: %#v", ctrl2)
+	}
+	if ctrl2.Namespace != "other" {
+		t.Errorf("Unexpected controller: %#v", ctrl2)
+	}
+
+}
+
+func TestEtcdGetControllerNotFound(t *testing.T) {
+	ctx := api.NewDefaultContext()
+	storage, fakeClient := newStorage(t)
+	key, _ := makeControllerKey(ctx, validController.Name)
+	key = etcdtest.AddPrefix(key)
+
+	fakeClient.Data[key] = tools.EtcdResponseWithError{
+		R: &etcd.Response{
+			Node: nil,
+		},
+		E: tools.EtcdErrorNotFound,
+	}
+	ctrl, err := storage.Get(ctx, validController.Name)
+	if ctrl != nil {
+		t.Errorf("Unexpected non-nil controller: %#v", ctrl)
+	}
+	if !errors.IsNotFound(err) {
+		t.Errorf("Unexpected error returned: %#v", err)
+	}
+}
+
+func TestEtcdUpdateController(t *testing.T) {
+	ctx := api.NewDefaultContext()
+	storage, fakeClient := newStorage(t)
+	key, _ := makeControllerKey(ctx, validController.Name)
+	key = etcdtest.AddPrefix(key)
+
+	// set a key, then retrieve the current resource version and try updating it
+	resp, _ := fakeClient.Set(key, runtime.EncodeOrDie(latest.Codec, &validController), 0)
+	update := validController
+	update.ResourceVersion = strconv.FormatUint(resp.Node.ModifiedIndex, 10)
+	_, created, err := storage.Update(ctx, &update)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if created {
+		t.Errorf("expected an update but created flag was returned")
+	}
+}
+
+func TestEtcdDeleteController(t *testing.T) {
+	ctx := api.NewDefaultContext()
+	storage, fakeClient := newStorage(t)
+	key, _ := makeControllerKey(ctx, validController.Name)
+	key = etcdtest.AddPrefix(key)
+
+	fakeClient.Set(key, runtime.EncodeOrDie(latest.Codec, &validController), 0)
+	obj, err := storage.Delete(ctx, validController.Name, nil)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if status, ok := obj.(*api.Status); !ok {
+		t.Errorf("Expected status of delete, got %#v", status)
+	} else if status.Status != api.StatusSuccess {
+		t.Errorf("Expected success, got %#v", status.Status)
+	}
+	if len(fakeClient.DeletedKeys) != 1 {
+		t.Errorf("Expected 1 delete, found %#v", fakeClient.DeletedKeys)
+	}
+	if fakeClient.DeletedKeys[0] != key {
+		t.Errorf("Unexpected key: %s, expected %s", fakeClient.DeletedKeys[0], key)
+	}
+}
+
+func TestEtcdListControllers(t *testing.T) {
+	storage, fakeClient := newStorage(t)
+	ctx := api.NewDefaultContext()
+	key := makeControllerListKey(ctx)
+	key = etcdtest.AddPrefix(key)
+	controller := validController
+	controller.Name = "bar"
+	fakeClient.Data[key] = tools.EtcdResponseWithError{
+		R: &etcd.Response{
+			Node: &etcd.Node{
+				Nodes: []*etcd.Node{
+					{
+						Value: runtime.EncodeOrDie(latest.Codec, &validController),
+					},
+					{
+						Value: runtime.EncodeOrDie(latest.Codec, &controller),
+					},
+				},
+			},
+		},
+		E: nil,
+	}
+	objList, err := storage.List(ctx, labels.Everything(), fields.Everything())
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	controllers, _ := objList.(*api.DaemonControllerList)
+	if len(controllers.Items) != 2 || controllers.Items[0].Name != validController.Name || controllers.Items[1].Name != controller.Name {
+		t.Errorf("Unexpected controller list: %#v", controllers)
+	}
+}
+
+func TestEtcdListControllersNotFound(t *testing.T) {
+	storage, fakeClient := newStorage(t)
+	ctx := api.NewDefaultContext()
+	key := makeControllerListKey(ctx)
+	key = etcdtest.AddPrefix(key)
+
+	fakeClient.Data[key] = tools.EtcdResponseWithError{
+		R: &etcd.Response{},
+		E: tools.EtcdErrorNotFound,
+	}
+	objList, err := storage.List(ctx, labels.Everything(), fields.Everything())
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	controllers, _ := objList.(*api.DaemonControllerList)
+	if len(controllers.Items) != 0 {
+		t.Errorf("Unexpected controller list: %#v", controllers)
+	}
+}
+
+func TestEtcdListControllersLabelsMatch(t *testing.T) {
+	storage, fakeClient := newStorage(t)
+	ctx := api.NewDefaultContext()
+	key := makeControllerListKey(ctx)
+	key = etcdtest.AddPrefix(key)
+
+	controller := validController
+	controller.Labels = map[string]string{"k": "v"}
+	controller.Name = "bar"
+
+	fakeClient.Data[key] = tools.EtcdResponseWithError{
+		R: &etcd.Response{
+			Node: &etcd.Node{
+				Nodes: []*etcd.Node{
+					{
+						Value: runtime.EncodeOrDie(latest.Codec, &validController),
+					},
+					{
+						Value: runtime.EncodeOrDie(latest.Codec, &controller),
+					},
+				},
+			},
+		},
+		E: nil,
+	}
+	testLabels := labels.SelectorFromSet(labels.Set(controller.Labels))
+	objList, err := storage.List(ctx, testLabels, fields.Everything())
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	controllers, _ := objList.(*api.DaemonControllerList)
+	if len(controllers.Items) != 1 || controllers.Items[0].Name != controller.Name ||
+		!testLabels.Matches(labels.Set(controllers.Items[0].Labels)) {
+		t.Errorf("Unexpected controller list: %#v for query with labels %#v",
+			controllers, testLabels)
+	}
+}
+
+func TestEtcdWatchController(t *testing.T) {
+	ctx := api.NewDefaultContext()
+	storage, fakeClient := newStorage(t)
+	watching, err := storage.Watch(ctx,
+		labels.Everything(),
+		fields.Everything(),
+		"1",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	fakeClient.WaitForWatchCompletion()
+
+	select {
+	case _, ok := <-watching.ResultChan():
+		if !ok {
+			t.Errorf("watching channel should be open")
+		}
+	default:
+	}
+	fakeClient.WatchInjectError <- nil
+	if _, ok := <-watching.ResultChan(); ok {
+		t.Errorf("watching channel should be closed")
+	}
+	watching.Stop()
+}
+
+// Tests that we can watch for the creation of daemon controllers with specified labels.
+func TestEtcdWatchControllersMatch(t *testing.T) {
+	ctx := api.WithNamespace(api.NewDefaultContext(), validController.Namespace)
+	storage, fakeClient := newStorage(t)
+	fakeClient.ExpectNotFoundGet(etcdgeneric.NamespaceKeyRootFunc(ctx, "/registry/pods"))
+
+	controllerLabels := map[string]string{
+		"name": "example_dc",
+	}
+	watching, err := storage.Watch(ctx,
+		labels.SelectorFromSet(controllerLabels),
+		fields.Everything(),
+		"1",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	fakeClient.WaitForWatchCompletion()
+
+	// The watcher above is waiting for these Labels, on receiving them it should
+	// apply the ControllerStatus decorator, which lists pods, causing a query against
+	// the /registry/pods endpoint of the etcd client.
+	controller := &api.DaemonController{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "foo",
+			Labels:    controllerLabels,
+			Namespace: "default",
+		},
+	}
+	controllerBytes, _ := latest.Codec.Encode(controller)
+	fakeClient.WatchResponse <- &etcd.Response{
+		Action: "create",
+		Node: &etcd.Node{
+			Value: string(controllerBytes),
+		},
+	}
+	select {
+	case _, ok := <-watching.ResultChan():
+		if !ok {
+			t.Errorf("watching channel should be open")
+		}
+	case <-time.After(time.Millisecond * 100):
+		t.Error("unexpected timeout from result channel")
+	}
+	watching.Stop()
+}
+
+// Tests that we can watch for daemon controllers with specified fields.
+func TestEtcdWatchControllersFields(t *testing.T) {
+	ctx := api.WithNamespace(api.NewDefaultContext(), validController.Namespace)
+	storage, fakeClient := newStorage(t)
+	fakeClient.ExpectNotFoundGet(etcdgeneric.NamespaceKeyRootFunc(ctx, "/registry/pods"))
+
+	testFieldMap := map[int][]fields.Set{
+		PASS: {
+			{"status.nodesRunningDaemon": "0"},
+			{"status.nodesShouldRunDaemon": "2"},
+			{"metadata.name": "foo"},
+			{"status.nodesRunningDaemon": "0", "status.nodesShouldRunDaemon": "2"},
+			{"status.nodesRunningDaemon": "0", "metadata.name": "foo"},
+			{"status.nodesShouldRunDaemon": "2", "metadata.name": "foo"},
+			{"status.nodesRunningDaemon": "0", "status.nodesShouldRunDaemon": "2", "metadata.name": "foo"},
+		},
+		FAIL: {
+			{"status.nodesRunningDaemon": "1"},
+			{"status.nodesShouldRunDaemon": "1"},
+			{"metadata.name": "bar"},
+			{"name": "foo"},
+			{"status.replicas": "5"},
+			{"status.nodesRunningDaemon": "0", "status.nodesShouldRunDaemon": "3"},
+			{"status.nodesRunningDaemon": "0", "status.nodesShouldRunDaemon": "2", "metadata.name": "foox"},
+		},
+	}
+	testEtcdActions := []string{
+		tools.EtcdCreate,
+		tools.EtcdSet,
+		tools.EtcdCAS,
+		tools.EtcdDelete}
+
+	controller := &api.DaemonController{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "foo",
+			Namespace: "default",
+		},
+		Status: api.DaemonControllerStatus{
+			NodesRunningDaemon:   0,
+			NodesShouldRunDaemon: 2,
+		},
+	}
+	controllerBytes, _ := latest.Codec.Encode(controller)
+
+	for expectedResult, fieldSet := range testFieldMap {
+		for _, field := range fieldSet {
+			for _, action := range testEtcdActions {
+				watching, err := storage.Watch(ctx,
+					labels.Everything(),
+					field.AsSelector(),
+					"1",
+				)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				var prevNode *etcd.Node = nil
+				node := &etcd.Node{
+					Value: string(controllerBytes),
+				}
+				if action == tools.EtcdDelete {
+					prevNode = node
+				}
+				fakeClient.WaitForWatchCompletion()
+				fakeClient.WatchResponse <- &etcd.Response{
+					Action:   action,
+					Node:     node,
+					PrevNode: prevNode,
+				}
+
+				select {
+				case r, ok := <-watching.ResultChan():
+					if expectedResult == FAIL {
+						t.Errorf("Unexpected result from channel %#v", r)
+					}
+					if !ok {
+						t.Errorf("watching channel should be open")
+					}
+				case <-time.After(time.Millisecond * 100):
+					if expectedResult == PASS {
+						t.Error("unexpected timeout from result channel")
+					}
+				}
+				watching.Stop()
+			}
+		}
+	}
+}
+
+func TestEtcdWatchControllersNotMatch(t *testing.T) {
+	ctx := api.NewDefaultContext()
+	storage, fakeClient := newStorage(t)
+	fakeClient.ExpectNotFoundGet(etcdgeneric.NamespaceKeyRootFunc(ctx, "/registry/pods"))
+
+	watching, err := storage.Watch(ctx,
+		labels.SelectorFromSet(labels.Set{"name": "foo"}),
+		fields.Everything(),
+		"1",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	fakeClient.WaitForWatchCompletion()
+
+	controller := &api.DaemonController{
+		ObjectMeta: api.ObjectMeta{
+			Name: "bar",
+			Labels: map[string]string{
+				"name": "bar",
+			},
+		},
+	}
+	controllerBytes, _ := latest.Codec.Encode(controller)
+	fakeClient.WatchResponse <- &etcd.Response{
+		Action: "create",
+		Node: &etcd.Node{
+			Value: string(controllerBytes),
+		},
+	}
+
+	select {
+	case <-watching.ResultChan():
+		t.Error("unexpected result from result channel")
+	case <-time.After(time.Millisecond * 100):
+		// expected case
+	}
+}
+
+func TestCreate(t *testing.T) {
+	storage, fakeClient := newStorage(t)
+	test := resttest.New(t, storage, fakeClient.SetError)
+	test.TestCreate(
+		// valid
+		&api.DaemonController{
+			Spec: api.DaemonControllerSpec{
+				Template: &validPodTemplate.Template,
+			},
+		},
+		// invalid
+		&api.DaemonController{
+			Spec: api.DaemonControllerSpec{
+				Template: &validPodTemplate.Template,
+			},
+		},
+	)
+}
+
+func TestDelete(t *testing.T) {
+	ctx := api.NewDefaultContext()
+	storage, fakeClient := newStorage(t)
+	test := resttest.New(t, storage, fakeClient.SetError)
+	key, _ := makeControllerKey(ctx, validController.Name)
+	key = etcdtest.AddPrefix(key)
+
+	createFn := func() runtime.Object {
+		dc := validController
+		dc.ResourceVersion = "1"
+		fakeClient.Data[key] = tools.EtcdResponseWithError{
+			R: &etcd.Response{
+				Node: &etcd.Node{
+					Value:         runtime.EncodeOrDie(latest.Codec, &dc),
+					ModifiedIndex: 1,
+				},
+			},
+		}
+		return &dc
+	}
+	gracefulSetFn := func() bool {
+		// If the controller is still around after trying to delete either the delete
+		// failed, or we're deleting it gracefully.
+		if fakeClient.Data[key].R.Node != nil {
+			return true
+		}
+		return false
+	}
+
+	test.TestDelete(createFn, gracefulSetFn)
+}

--- a/pkg/registry/daemoncontroller/rest.go
+++ b/pkg/registry/daemoncontroller/rest.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package daemoncontroller
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
+)
+
+// dcStrategy implements verification logic for daemon Controllers.
+type dcStrategy struct {
+	runtime.ObjectTyper
+	api.NameGenerator
+}
+
+// Strategy is the default logic that applies when creating and updating Daemon Controller objects.
+var Strategy = dcStrategy{api.Scheme, api.SimpleNameGenerator}
+
+// NamespaceScoped returns true because all Daemon Controllers need to be within a namespace.
+func (dcStrategy) NamespaceScoped() bool {
+	return true
+}
+
+// PrepareForCreate clears the status of a daemon controller before creation.
+func (dcStrategy) PrepareForCreate(obj runtime.Object) {
+	controller := obj.(*api.DaemonController)
+	controller.Status = api.DaemonControllerStatus{}
+}
+
+// PrepareForUpdate clears fields that are not allowed to be set by end users on update.
+func (dcStrategy) PrepareForUpdate(obj, old runtime.Object) {
+	newController := obj.(*api.DaemonController)
+	oldController := old.(*api.DaemonController)
+	newController.Status = oldController.Status
+}
+
+// Validate validates a new daemon controller.
+func (dcStrategy) Validate(ctx api.Context, obj runtime.Object) fielderrors.ValidationErrorList {
+	controller := obj.(*api.DaemonController)
+	return validation.ValidateDaemonController(controller)
+}
+
+// AllowCreateOnUpdate is false for daemon controllers; this means a POST is
+// needed to create one.
+func (dcStrategy) AllowCreateOnUpdate() bool {
+	return false
+}
+
+// ValidateUpdate is the default update validation for an end user.
+func (dcStrategy) ValidateUpdate(ctx api.Context, obj, old runtime.Object) fielderrors.ValidationErrorList {
+	validationErrorList := validation.ValidateDaemonController(obj.(*api.DaemonController))
+	updateErrorList := validation.ValidateDaemonControllerUpdate(old.(*api.DaemonController), obj.(*api.DaemonController))
+	return append(validationErrorList, updateErrorList...)
+}
+
+// ControllerToSelectableFields returns a label set that represents the object.
+func ControllerToSelectableFields(controller *api.DaemonController) fields.Set {
+	return fields.Set{
+		"metadata.name":               controller.Name,
+		"status.nodesRunningDaemon":   strconv.Itoa(controller.Status.NodesRunningDaemon),
+		"status.nodesShouldRunDaemon": strconv.Itoa(controller.Status.NodesShouldRunDaemon),
+	}
+}
+
+// MatchController is the filter used by the generic etcd backend to route
+// watch events from etcd to clients of the apiserver only interested in specific
+// labels/fields.
+func MatchController(label labels.Selector, field fields.Selector) generic.Matcher {
+	return &generic.SelectionPredicate{
+		Label: label,
+		Field: field,
+		GetAttrs: func(obj runtime.Object) (labels.Set, fields.Set, error) {
+			dc, ok := obj.(*api.DaemonController)
+			if !ok {
+				return nil, nil, fmt.Errorf("given object is not a daemon controller.")
+			}
+			return labels.Set(dc.ObjectMeta.Labels), ControllerToSelectableFields(dc), nil
+		},
+	}
+}


### PR DESCRIPTION
A note: The Replication Controller Spec contains both a PodTemplateSpec and an ObjectReference. So far I omitted the ObjectReference from the Daemon Controller Spec because I couldn't identify where the ObjectReference is used (my guess is that it's used in older versions of the API). If necessary, I'll add the ObjectReference back in.

Also, this code compiles but doesn't pass tests yet. I need to add type specifications for the Daemon Controller in v1beta1, v1beta2, v1beta3, etc. I'll work on those additions now, but I wanted to send this "partial" PR. Thanks for taking the time to review!
